### PR TITLE
Fix Cloudflare Pages deployment error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,4 +104,4 @@ jobs:
           projectName: personal-hub
           directory: apps/frontend/dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          production: true
+          branch: main


### PR DESCRIPTION
## Summary
- Fixed deployment error caused by unsupported 'production' parameter in cloudflare/pages-action@v1
- Replaced with 'branch: main' to properly deploy to production
- Created Cloudflare Pages project 'personal-hub' via CLI

## Problem
The deployment to Cloudflare Pages was failing with:
- "Unexpected input(s) 'production'" warning
- "Project not found" error for 'personal-hub' project

## Solution
1. Removed the unsupported `production: true` parameter
2. Added `branch: main` to deploy to production when pushing to main branch
3. Created the missing Cloudflare Pages project using `wrangler pages project create`

## Test plan
- [x] Created Cloudflare Pages project via CLI
- [ ] CI checks should pass
- [ ] Deployment should succeed when merged to main

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to specify the deployment branch as "main" instead of using a production flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->