### PR TITLE
Fix Cloudflare Pages deployment errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,9 @@ jobs:
     name: Deploy Frontend to Cloudflare Pages
     runs-on: ubuntu-latest
     needs: deploy-backend
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,4 +104,4 @@ jobs:
           projectName: personal-hub
           directory: apps/frontend/dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          production: true
+          branch: main


### PR DESCRIPTION
## Summary
- Fixed deployment error caused by unsupported 'production' parameter in cloudflare/pages-action@v1
- Added necessary GitHub permissions for deployment creation
- Created Cloudflare Pages project 'personal-hub' via CLI

## Problem
The deployment to Cloudflare Pages was failing with two issues:
1. "Unexpected input(s) 'production'" warning - unsupported parameter
2. "Resource not accessible by integration" - missing deployment permissions

## Solution
1. Removed the unsupported `production: true` parameter
2. Added `branch: main` to deploy to production when pushing to main branch
3. Added `permissions` section with `deployments: write` to allow GitHub deployment creation
4. Created the Cloudflare Pages project using `wrangler pages project create`

## Changes
- Removed `production: true` parameter from Cloudflare Pages action
- Added `branch: main` parameter
- Added permissions section to frontend deployment job:
  ```yaml
  permissions:
    contents: read
    deployments: write
  ```

## Test plan
- [x] Created Cloudflare Pages project via CLI
- [ ] CI checks should pass
- [ ] Deployment should succeed when merged to main

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration for improved permissions and deployment targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->