### PR TITLE
fix: Cross-domain authentication issue in production

### DIFF
--- a/apps/backend/src/middleware/csrf.ts
+++ b/apps/backend/src/middleware/csrf.ts
@@ -74,7 +74,7 @@ export function setCSRFCookie(c: Context, token: string) {
   setCookie(c, CSRF_TOKEN_COOKIE, token, {
     httpOnly: false, // Must be accessible by JavaScript to read and send in header
     secure: isProduction,
-    sameSite: isProduction ? 'Strict' : 'Lax', // Use Lax for development/testing
+    sameSite: isProduction ? 'None' : 'Lax', // Use 'None' for cross-domain in production
     path: '/',
     maxAge: 86400, // 24 hours
   });

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -38,7 +38,7 @@ function setAuthCookies(c: Context<{ Bindings: Bindings; Variables: Variables }>
   setCookie(c, ACCESS_TOKEN_COOKIE, accessToken, {
     httpOnly: true,
     secure: isProduction,
-    sameSite: isProduction ? 'Strict' : 'Lax',
+    sameSite: isProduction ? 'None' : 'Lax', // Use 'None' for cross-domain in production
     path: '/',
     maxAge: 15 * 60, // 15 minutes
   });
@@ -47,7 +47,7 @@ function setAuthCookies(c: Context<{ Bindings: Bindings; Variables: Variables }>
   setCookie(c, REFRESH_TOKEN_COOKIE, refreshToken, {
     httpOnly: true,
     secure: isProduction,
-    sameSite: isProduction ? 'Strict' : 'Lax',
+    sameSite: isProduction ? 'None' : 'Lax', // Use 'None' for cross-domain in production
     path: '/',
     maxAge: 7 * 24 * 60 * 60, // 7 days
   });
@@ -60,7 +60,7 @@ function setAuthCookies(c: Context<{ Bindings: Bindings; Variables: Variables }>
   setCookie(c, SESSION_COOKIE, JSON.stringify(sessionData), {
     httpOnly: true,
     secure: isProduction,
-    sameSite: isProduction ? 'Strict' : 'Lax',
+    sameSite: isProduction ? 'None' : 'Lax', // Use 'None' for cross-domain in production
     path: '/',
     maxAge: 30 * 60, // 30 minutes
   });


### PR DESCRIPTION
## Summary
- Fixed authentication issues where users were redirected to login when navigating between pages in production
- Changed SameSite cookie attribute from 'Strict' to 'None' for cross-domain cookie support

## Problem
In production, the frontend (personal-hub.pages.dev) and backend (personal-hub-backend-prod.zametech.workers.dev) are on different domains. With `SameSite: 'Strict'`, cookies were not being sent between domains, causing authentication to fail when navigating to different pages like TODO.

## Solution
Changed cookie settings in production to use `SameSite: 'None'` (with `Secure: true`) for:
- Auth cookies (access-token, refresh-token, session-id) 
- CSRF token cookie

This allows cookies to be properly sent in cross-domain requests while maintaining security.

## Test plan
- [x] Backend tests pass
- [ ] Deploy to production
- [ ] Verify login works
- [ ] Verify navigation between pages maintains authentication
- [ ] Verify TODO page is accessible after login

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated cookie settings to allow cross-domain authentication in production environments by changing the `sameSite` attribute to `None` for relevant cookies.

* **Chores**
  * Adjusted cookie configuration for improved compatibility with cross-site requests in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->