### PR TITLE
fix: Convert note tags from backend string to frontend array format

### DIFF
--- a/apps/frontend/src/lib/note-api.ts
+++ b/apps/frontend/src/lib/note-api.ts
@@ -1,6 +1,17 @@
 import { Note, CreateNoteDto, UpdateNoteDto, NoteFilters } from '@/types/note';
 import { getCachedCSRFToken } from './csrf';
 
+// Type for note data as received from backend (with tags as string)
+interface BackendNote {
+  id: string;
+  title: string;
+  content: string;
+  tags: string;
+  createdAt: string;
+  updatedAt: string;
+  userId: string;
+}
+
 const API_BASE_URL = import.meta.env?.VITE_API_BASE_URL || 'http://localhost:8787';
 
 function getAuthHeaders(includeCSRF: boolean = false): HeadersInit {
@@ -34,7 +45,12 @@ export async function fetchNotes(filters?: NoteFilters): Promise<Note[]> {
   }
 
   const data = await response.json();
-  return data.items || [];
+  // Convert tags from string to array for each note
+  const notes = (data.items || []).map((note: BackendNote) => ({
+    ...note,
+    tags: note.tags ? note.tags.split(',').map((t: string) => t.trim()).filter((t: string) => t) : []
+  }));
+  return notes;
 }
 
 export async function fetchNoteTags(): Promise<string[]> {
@@ -72,7 +88,11 @@ export async function createNote(note: CreateNoteDto): Promise<Note> {
   }
 
   const data = await response.json();
-  return data; // Backend returns the note object directly
+  // Convert tags from string to array
+  return {
+    ...data,
+    tags: data.tags ? data.tags.split(',').map((t: string) => t.trim()).filter((t: string) => t) : []
+  };
 }
 
 export async function updateNote(id: string, updates: UpdateNoteDto): Promise<Note> {
@@ -95,7 +115,11 @@ export async function updateNote(id: string, updates: UpdateNoteDto): Promise<No
   }
 
   const data = await response.json();
-  return data; // Backend returns the note object directly
+  // Convert tags from string to array
+  return {
+    ...data,
+    tags: data.tags ? data.tags.split(',').map((t: string) => t.trim()).filter((t: string) => t) : []
+  };
 }
 
 export async function deleteNote(id: string): Promise<void> {

--- a/todo.md
+++ b/todo.md
@@ -22,6 +22,7 @@ This file tracks pending tasks organized by feature.
 ## Calendar Feature
 
 ## Notes Feature
+- [HIGH] Fix NoteList.tsx TypeError when adding notes - tags.slice is not a function (Fixed in PR)
 
 ## Goals Feature
 


### PR DESCRIPTION
## Summary
- Fixed TypeError "tags.slice is not a function" when adding notes
- Backend stores tags as comma-separated strings, frontend expects arrays
- Added proper TypeScript types and conversion logic in API layer

## Problem
When creating or editing notes, the application would crash with:
```
NoteList.tsx:100 Uncaught TypeError: s.tags.slice(...).map is not a function
```

This occurred because the backend API returns tags as a comma-separated string (e.g., "tag1,tag2,tag3") but the frontend components expect an array of strings.

## Solution
- Added `BackendNote` interface to properly type backend responses
- Implemented conversion logic in `fetchNotes()`, `createNote()`, and `updateNote()`
- Tags are now converted from string to array format when receiving API responses
- Handles null/undefined tags gracefully with empty array fallback

## Test plan
- [x] Lint check passes
- [x] Type check passes  
- [x] Unit tests pass (256 tests)
- [x] E2E tests pass (including note creation test)
- [x] Build succeeds
- [x] Manual testing: Create, edit, and view notes with tags

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved an issue where adding notes could fail due to tag handling.
  - Ensures tags are consistently parsed, displayed, and saved across viewing, creating, and updating notes.
  - Prevents empty or whitespace-only tags from appearing.
- Documentation
  - Updated TODOs to reflect the resolved tags-related bug in note creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->