### PR TITLE
fix: Resolve 403 Forbidden errors on TODO endpoints

### DIFF
--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -102,6 +102,21 @@ function clearAuthCookies(c: Context<{ Bindings: Bindings; Variables: Variables 
     secure: isProduction,
     sameSite: sameSite as 'None' | 'Lax',
   });
+  
+  // Clear CSRF token cookie (not httpOnly since it needs to be read by JavaScript)
+  setCookie(c, 'csrf-token', '', {
+    httpOnly: false,
+    secure: isProduction,
+    sameSite: sameSite as 'None' | 'Lax',
+    path: '/',
+    maxAge: 0,
+    expires: new Date(0),
+  });
+  deleteCookie(c, 'csrf-token', {
+    path: '/',
+    secure: isProduction,
+    sameSite: sameSite as 'None' | 'Lax',
+  });
 }
 
 // Validation schemas - matching Spring Boot requirements
@@ -460,8 +475,11 @@ app.get('/me', authMiddleware, async (c) => {
     return c.text('Forbidden', StatusCodes.FORBIDDEN as ContentfulStatusCode);
   }
   
-  // Generate and set CSRF token for authenticated user
-  const csrfToken = generateAndSetCSRFToken(c);
+  // Only generate and set CSRF token if one doesn't exist
+  let csrfToken = getCookie(c, 'csrf-token');
+  if (!csrfToken) {
+    csrfToken = generateAndSetCSRFToken(c);
+  }
   
   // Return user data in Spring Boot format with CSRF token
   return c.json({

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -460,7 +460,10 @@ app.get('/me', authMiddleware, async (c) => {
     return c.text('Forbidden', StatusCodes.FORBIDDEN as ContentfulStatusCode);
   }
   
-  // Return user data in Spring Boot format
+  // Generate and set CSRF token for authenticated user
+  const csrfToken = generateAndSetCSRFToken(c);
+  
+  // Return user data in Spring Boot format with CSRF token
   return c.json({
     id: user.id,
     username: user.username,
@@ -468,6 +471,7 @@ app.get('/me', authMiddleware, async (c) => {
     weekStartDay: user.weekStartDay,
     createdAt: user.createdAt,
     updatedAt: user.updatedAt,
+    csrfToken
   });
 });
 

--- a/apps/frontend/src/contexts/AuthContext.tsx
+++ b/apps/frontend/src/contexts/AuthContext.tsx
@@ -199,12 +199,23 @@ export function AuthProvider({ children }: AuthProviderProps) {
       dispatch({ type: 'AUTH_LOADING' })
       const response = await apiClient.get('/api/v1/auth/me')
       
+      // Extract csrf token and user fields from /auth/me response
+      const { csrfToken, ...userFields } = response.data ?? {}
+      
       // Cache CSRF token if provided
-      if (response.data.csrfToken) {
-        setCachedCSRFToken(response.data.csrfToken)
+      if (csrfToken) {
+        setCachedCSRFToken(csrfToken)
       }
       
-      dispatch({ type: 'AUTH_SUCCESS', payload: response.data })
+      // Normalize user shape (ensure roles field exists)
+      const user: User = {
+        id: userFields.id,
+        username: userFields.username,
+        email: userFields.email,
+        roles: Array.isArray(userFields.roles) ? userFields.roles : [],
+      }
+      
+      dispatch({ type: 'AUTH_SUCCESS', payload: user })
     } catch (error) {
       const axiosError = error as ApiErrorResponse
       

--- a/apps/frontend/src/contexts/AuthContext.tsx
+++ b/apps/frontend/src/contexts/AuthContext.tsx
@@ -198,6 +198,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
     try {
       dispatch({ type: 'AUTH_LOADING' })
       const response = await apiClient.get('/api/v1/auth/me')
+      
+      // Cache CSRF token if provided
+      if (response.data.csrfToken) {
+        setCachedCSRFToken(response.data.csrfToken)
+      }
+      
       dispatch({ type: 'AUTH_SUCCESS', payload: response.data })
     } catch (error) {
       const axiosError = error as ApiErrorResponse

--- a/todo.md
+++ b/todo.md
@@ -22,7 +22,6 @@ This file tracks pending tasks organized by feature.
 ## Calendar Feature
 
 ## Notes Feature
-- [HIGH] Fix NoteList.tsx TypeError when adding notes - tags.slice is not a function (Fixed in PR)
 
 ## Goals Feature
 


### PR DESCRIPTION
## Summary
- Fixed 403 Forbidden errors that occurred when creating or completing todos after page refresh
- Added CSRF token generation to the `/api/v1/auth/me` endpoint
- Updated frontend to cache CSRF tokens received from auth checks

## Problem
Users were encountering 403 Forbidden errors when trying to:
- Create new todos (POST `/api/v1/todos`)
- Complete todos (POST `/api/v1/todos/:id/complete`)

This happened specifically after refreshing the page, as CSRF tokens were only being set during login/register but not on subsequent authentication checks.

## Solution
1. Modified `/api/v1/auth/me` endpoint to generate and return a CSRF token for authenticated users
2. Updated `AuthContext.tsx` to cache the CSRF token when received from the auth check
3. This ensures users always have a valid CSRF token for making POST requests to protected endpoints

## Test Results
- ✅ All unit tests pass
- ✅ Linting passes
- ✅ Type checking passes
- ✅ Quality gate checks pass

## Notes
The code reviewer identified some potential security improvements for future iterations (such as not exposing CSRF tokens in API responses), but the current implementation successfully resolves the immediate issue while maintaining backward compatibility.

Fixes #21 (TODO Feature - 403 Forbidden errors)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Account info endpoint now returns a CSRF token with user details.
  - App caches the CSRF token when loading the current user for consistent availability across login, registration, and session refresh.

- Bug Fixes
  - Logout now reliably removes the CSRF cookie from the client.

- Documentation
  - Removed a resolved high-priority TODO about a note-related issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->