### PR TITLE
feat: Enhance Command Palette with history, accessibility, and reliability improvements

### DIFF
--- a/apps/frontend/src/components/CommandPalette.tsx
+++ b/apps/frontend/src/components/CommandPalette.tsx
@@ -5,7 +5,7 @@ import { Modal } from './ui/Modal';
 import { Command } from '../types/command-palette';
 import { useTranslation } from 'react-i18next';
 import { VirtualCommandList } from './VirtualCommandList';
-import { commandRegistry } from '../lib/command-registry';
+import { useCommandHistory } from '../hooks/useCommandHistory';
 
 // Memoize command item to prevent re-renders
 const CommandItem = memo(({ 
@@ -83,6 +83,7 @@ export function CommandPalette() {
     selectPrevious,
     executeSelectedCommand,
   } = useCommandPalette();
+  const { history } = useCommandHistory();
 
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -150,24 +151,16 @@ export function CommandPalette() {
   const groupedCommands = useMemo(() => {
     const groups = new Map<string, Command[]>();
     const historyGroup: Command[] = [];
-    
-    // When there's no search query, first 5 commands are from history
+
+    // No search: provider orders filteredCommands as [history..., nonHistory...]
     if (!state.searchQuery && state.filteredCommands.length > 0) {
-      const historyCount = Math.min(5, state.filteredCommands.length);
-      for (let i = 0; i < historyCount; i++) {
-        const cmd = state.filteredCommands[i];
-        // Check if this is a history command by seeing if it would be in normal order
-        const allCommands = commandRegistry.getAvailableCommands();
-        const normalIndex = allCommands.findIndex(c => c.id === cmd.id);
-        if (normalIndex >= historyCount) {
-          historyGroup.push(cmd);
-        } else {
-          break;
-        }
+      const historyCount = Math.min(history.length, state.filteredCommands.length);
+      if (historyCount > 0) {
+        historyGroup.push(...state.filteredCommands.slice(0, historyCount));
       }
     }
-    
-    // Group remaining commands by category
+
+    // Group remaining (non-history) commands by category
     const startIndex = historyGroup.length;
     state.filteredCommands.slice(startIndex).forEach((command) => {
       const category = command.category;
@@ -181,13 +174,15 @@ export function CommandPalette() {
     if (historyGroup.length > 0) {
       result.push({ category: 'history', commands: historyGroup });
     }
-    result.push(...Array.from(groups.entries()).map(([category, commands]) => ({
-      category,
-      commands,
-    })));
-    
+    result.push(
+      ...Array.from(groups.entries()).map(([category, commands]) => ({
+        category,
+        commands,
+      }))
+    );
+
     return result;
-  }, [state.filteredCommands, state.searchQuery]);
+  }, [state.filteredCommands, state.searchQuery, history]);
   
   // Memoize handler for item hover
   const handleItemHover = useCallback((index: number) => {

--- a/apps/frontend/src/components/CommandPalette.tsx
+++ b/apps/frontend/src/components/CommandPalette.tsx
@@ -5,6 +5,7 @@ import { Modal } from './ui/Modal';
 import { Command } from '../types/command-palette';
 import { useTranslation } from 'react-i18next';
 import { VirtualCommandList } from './VirtualCommandList';
+import { commandRegistry } from '../lib/command-registry';
 
 // Memoize command item to prevent re-renders
 const CommandItem = memo(({ 
@@ -131,6 +132,8 @@ export function CommandPalette() {
 
   const getCategoryLabel = useCallback((category: string) => {
     switch (category) {
+      case 'history':
+        return t('commandPalette.categories.history', 'History');
       case 'navigation':
         return t('commandPalette.categories.navigation', 'Navigation');
       case 'action':
@@ -146,8 +149,27 @@ export function CommandPalette() {
 
   const groupedCommands = useMemo(() => {
     const groups = new Map<string, Command[]>();
+    const historyGroup: Command[] = [];
     
-    state.filteredCommands.forEach((command) => {
+    // When there's no search query, first 5 commands are from history
+    if (!state.searchQuery && state.filteredCommands.length > 0) {
+      const historyCount = Math.min(5, state.filteredCommands.length);
+      for (let i = 0; i < historyCount; i++) {
+        const cmd = state.filteredCommands[i];
+        // Check if this is a history command by seeing if it would be in normal order
+        const allCommands = commandRegistry.getAvailableCommands();
+        const normalIndex = allCommands.findIndex(c => c.id === cmd.id);
+        if (normalIndex >= historyCount) {
+          historyGroup.push(cmd);
+        } else {
+          break;
+        }
+      }
+    }
+    
+    // Group remaining commands by category
+    const startIndex = historyGroup.length;
+    state.filteredCommands.slice(startIndex).forEach((command) => {
       const category = command.category;
       if (!groups.has(category)) {
         groups.set(category, []);
@@ -155,11 +177,17 @@ export function CommandPalette() {
       groups.get(category)!.push(command);
     });
 
-    return Array.from(groups.entries()).map(([category, commands]) => ({
+    const result = [];
+    if (historyGroup.length > 0) {
+      result.push({ category: 'history', commands: historyGroup });
+    }
+    result.push(...Array.from(groups.entries()).map(([category, commands]) => ({
       category,
       commands,
-    }));
-  }, [state.filteredCommands]);
+    })));
+    
+    return result;
+  }, [state.filteredCommands, state.searchQuery]);
   
   // Memoize handler for item hover
   const handleItemHover = useCallback((index: number) => {
@@ -183,7 +211,7 @@ export function CommandPalette() {
       onClose={closeCommandPalette}
       className="max-w-2xl mx-auto mt-20"
     >
-      <div className="flex flex-col max-h-[70vh]" role="combobox" aria-expanded="true" aria-haspopup="listbox" aria-owns="command-list">
+      <div className="flex flex-col h-[600px] max-h-[80vh]" role="combobox" aria-expanded="true" aria-haspopup="listbox" aria-owns="command-list">
         <div className="flex items-center border-b border-gray-200 dark:border-gray-700 px-4 py-3">
           <Search className="w-5 h-5 text-gray-400 mr-3" aria-hidden="true" />
           <input
@@ -213,7 +241,7 @@ export function CommandPalette() {
           {state.filteredCommands.length} {t('commandPalette.resultsFound', 'commands found')}
         </div>
 
-        <div ref={listRef} id="command-list" role="listbox" className="flex-1 overflow-y-auto py-2" aria-label="Command suggestions">
+        <div ref={listRef} id="command-list" role="listbox" className="flex-1 min-h-0 overflow-y-auto py-2" aria-label="Command suggestions">
           {state.filteredCommands.length === 0 ? (
             <div className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
               {state.searchQuery
@@ -268,7 +296,7 @@ export function CommandPalette() {
           )}
         </div>
 
-        <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-2 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+        <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 px-4 py-2 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
           <div className="flex items-center gap-4">
             <span className="flex items-center gap-1">
               <kbd className="px-1.5 py-0.5 font-semibold bg-gray-100 dark:bg-gray-800 rounded">↑</kbd>

--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
-import { Menu, User, LogOut, Settings, ChevronDown, Sun, Moon, Languages } from 'lucide-react';
+import { useCommandPalette } from '@/contexts/CommandPaletteContext';
+import { Menu, User, LogOut, Settings, ChevronDown, Sun, Moon, Languages, Terminal } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -12,6 +13,7 @@ interface HeaderProps {
 export function Header({ onMenuClick }: HeaderProps) {
   const { user, logout } = useAuth();
   const { theme, toggleTheme } = useTheme();
+  const { openCommandPalette } = useCommandPalette();
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const { t, i18n } = useTranslation('common');
   
@@ -56,6 +58,20 @@ export function Header({ onMenuClick }: HeaderProps) {
                 <option value="ja">日本語</option>
               </select>
             </div>
+            
+            {/* Command Palette Button */}
+            <button
+              onClick={openCommandPalette}
+              className="p-2 rounded-md text-foreground hover:bg-muted transition-colors group relative"
+              aria-label="Open command palette (Ctrl+K)"
+              title="Command Palette (Ctrl+K)"
+            >
+              <Terminal className="h-5 w-5" />
+              {/* Tooltip on hover */}
+              <span className="absolute hidden group-hover:block bottom-full right-0 mb-2 px-2 py-1 text-xs bg-gray-900 dark:bg-gray-700 text-white rounded whitespace-nowrap">
+                Ctrl+K
+              </span>
+            </button>
             
             {/* Theme Toggle */}
             <button

--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFeatures } from '@/contexts/FeatureContext';
+import { useCommandPalette } from '@/contexts/CommandPaletteContext';
 import { 
   Home, 
   CheckSquare, 
@@ -12,7 +13,8 @@ import {
   Clock,
   Timer,
   Settings,
-  X
+  X,
+  Terminal
 } from 'lucide-react';
 
 interface NavItem {
@@ -30,6 +32,7 @@ export function Sidebar({ isOpen = false, onClose }: SidebarProps) {
   const location = useLocation();
   const { t } = useTranslation('common');
   const { features: featurePreferences } = useFeatures();
+  const { openCommandPalette } = useCommandPalette();
 
   // Close sidebar on route change (mobile)
   useEffect(() => {
@@ -136,6 +139,23 @@ export function Sidebar({ isOpen = false, onClose }: SidebarProps) {
             aria-label="Close menu"
           >
             <X className="h-5 w-5" />
+          </button>
+        </div>
+        
+        {/* Command Palette Button - Mobile Only */}
+        <div className="px-3 pb-3 md:hidden">
+          <button
+            onClick={() => {
+              openCommandPalette();
+              onClose?.();
+            }}
+            className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium bg-primary/10 text-primary"
+          >
+            <Terminal className="h-5 w-5" />
+            <span>{t('commandPalette.title', 'Command Palette')}</span>
+            <kbd className="ml-auto px-2 py-0.5 text-xs font-semibold bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded">
+              Ctrl+K
+            </kbd>
           </button>
         </div>
 

--- a/apps/frontend/src/contexts/CommandPaletteContext.tsx
+++ b/apps/frontend/src/contexts/CommandPaletteContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback, use
 import { CommandPaletteState } from '../types/command-palette';
 import { commandRegistry } from '../lib/command-registry';
 import { debounce } from '../utils/debounce';
+import { useCommandHistory } from '../hooks/useCommandHistory';
 
 interface CommandPaletteContextValue {
   state: CommandPaletteState;
@@ -25,6 +26,7 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const { addToHistory, getRecentCommandIds } = useCommandHistory();
   const [recentCommands, setRecentCommands] = useState<string[]>(() => {
     // Use sessionStorage for temporary data to avoid security issues
     try {
@@ -58,21 +60,21 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
       return commandRegistry.searchCommands(debouncedQuery);
     }
     
-    // Only recalculate when actually needed
-    const recent = recentCommands
-      .slice(0, MAX_RECENT_COMMANDS)
+    // Get commands from history
+    const historyCommandIds = getRecentCommandIds();
+    const historyCommands = historyCommandIds
       .map(id => commandRegistry.getCommand(id))
       .filter((cmd): cmd is NonNullable<typeof cmd> => 
         cmd !== undefined && (!cmd.isAvailable || cmd.isAvailable())
       );
     
     const allAvailable = commandRegistry.getAvailableCommands();
-    const nonRecent = allAvailable.filter(
-      cmd => !recentCommands.includes(cmd.id)
+    const nonHistory = allAvailable.filter(
+      cmd => !historyCommandIds.includes(cmd.id)
     );
     
-    return [...recent, ...nonRecent];
-  }, [debouncedQuery, recentCommands]);
+    return [...historyCommands, ...nonHistory];
+  }, [debouncedQuery, getRecentCommandIds]);
 
   const state: CommandPaletteState = {
     isOpen,
@@ -141,6 +143,7 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
     if (command) {
       closeCommandPalette();
       addRecentCommand(command.id);
+      addToHistory(command.id);
       
       // Handle both sync and async command execution with error handling
       try {
@@ -160,7 +163,7 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
         // toast.error(`Failed to execute: ${command.title}`);
       }
     }
-  }, [filteredCommands, selectedIndex, closeCommandPalette, addRecentCommand]);
+  }, [filteredCommands, selectedIndex, closeCommandPalette, addRecentCommand, addToHistory]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/apps/frontend/src/contexts/CommandPaletteContext.tsx
+++ b/apps/frontend/src/contexts/CommandPaletteContext.tsx
@@ -26,7 +26,7 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const { addToHistory, getRecentCommandIds } = useCommandHistory();
+  const { history, addToHistory } = useCommandHistory();
   const [recentCommands, setRecentCommands] = useState<string[]>(() => {
     // Use sessionStorage for temporary data to avoid security issues
     try {
@@ -60,21 +60,22 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
       return commandRegistry.searchCommands(debouncedQuery);
     }
     
-    // Get commands from history
-    const historyCommandIds = getRecentCommandIds();
+    // Get commands from persisted history
+    const historyCommandIds = history.map((e) => e.commandId);
+    const historyIdSet = new Set(historyCommandIds);
+
     const historyCommands = historyCommandIds
-      .map(id => commandRegistry.getCommand(id))
-      .filter((cmd): cmd is NonNullable<typeof cmd> => 
-        cmd !== undefined && (!cmd.isAvailable || cmd.isAvailable())
+      .map((id) => commandRegistry.getCommand(id))
+      .filter(
+        (cmd): cmd is NonNullable<typeof cmd> =>
+          cmd !== undefined && (!cmd.isAvailable || cmd.isAvailable())
       );
-    
+
     const allAvailable = commandRegistry.getAvailableCommands();
-    const nonHistory = allAvailable.filter(
-      cmd => !historyCommandIds.includes(cmd.id)
-    );
-    
+    const nonHistory = allAvailable.filter((cmd) => !historyIdSet.has(cmd.id));
+
     return [...historyCommands, ...nonHistory];
-  }, [debouncedQuery, getRecentCommandIds]);
+  }, [debouncedQuery, history]);
 
   const state: CommandPaletteState = {
     isOpen,

--- a/apps/frontend/src/hooks/useCommandHistory.ts
+++ b/apps/frontend/src/hooks/useCommandHistory.ts
@@ -1,0 +1,89 @@
+import { useState, useCallback } from 'react';
+
+export interface CommandHistoryEntry {
+  commandId: string;
+  timestamp: number;
+  usageCount: number;
+}
+
+const HISTORY_KEY = 'commandPalette.history';
+const MAX_HISTORY_ITEMS = 5;
+
+export function useCommandHistory() {
+  const [history, setHistory] = useState<CommandHistoryEntry[]>(() => {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        const stored = localStorage.getItem(HISTORY_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          return Array.isArray(parsed) ? parsed : [];
+        }
+      }
+    } catch (e) {
+      console.warn('Failed to load command history:', e);
+    }
+    return [];
+  });
+
+  const saveHistory = useCallback((entries: CommandHistoryEntry[]) => {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        localStorage.setItem(HISTORY_KEY, JSON.stringify(entries));
+      }
+    } catch (e) {
+      console.warn('Failed to save command history:', e);
+    }
+  }, []);
+
+  const addToHistory = useCallback((commandId: string) => {
+    setHistory(prev => {
+      const existing = prev.find(entry => entry.commandId === commandId);
+      let updated: CommandHistoryEntry[];
+      
+      if (existing) {
+        updated = prev.map(entry =>
+          entry.commandId === commandId
+            ? { ...entry, timestamp: Date.now(), usageCount: entry.usageCount + 1 }
+            : entry
+        );
+      } else {
+        updated = [
+          { commandId, timestamp: Date.now(), usageCount: 1 },
+          ...prev
+        ].slice(0, MAX_HISTORY_ITEMS);
+      }
+      
+      updated.sort((a, b) => {
+        const scoreDiff = b.usageCount - a.usageCount;
+        if (scoreDiff !== 0) return scoreDiff;
+        return b.timestamp - a.timestamp;
+      });
+      
+      const limited = updated.slice(0, MAX_HISTORY_ITEMS);
+      saveHistory(limited);
+      return limited;
+    });
+  }, [saveHistory]);
+
+  const clearHistory = useCallback(() => {
+    setHistory([]);
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        localStorage.removeItem(HISTORY_KEY);
+      }
+    } catch (e) {
+      console.warn('Failed to clear command history:', e);
+    }
+  }, []);
+
+  const getRecentCommandIds = useCallback((): string[] => {
+    return history.map(entry => entry.commandId);
+  }, [history]);
+
+  return {
+    history,
+    addToHistory,
+    clearHistory,
+    getRecentCommandIds
+  };
+}

--- a/apps/frontend/src/hooks/useCommandHistory.ts
+++ b/apps/frontend/src/hooks/useCommandHistory.ts
@@ -50,7 +50,7 @@ export function useCommandHistory() {
         updated = [
           { commandId, timestamp: Date.now(), usageCount: 1 },
           ...prev
-        ].slice(0, MAX_HISTORY_ITEMS);
+        ];
       }
       
       updated.sort((a, b) => {

--- a/apps/frontend/src/lib/command-registry.ts
+++ b/apps/frontend/src/lib/command-registry.ts
@@ -104,9 +104,19 @@ class CommandRegistry {
       return this.availableCommandsCache;
     }
     
-    const available = this.getAllCommands().filter(
-      (cmd) => !cmd.isAvailable || cmd.isAvailable()
-    );
+    const available = this.getAllCommands()
+      .filter((cmd) => !cmd.isAvailable || cmd.isAvailable())
+      .sort((a, b) => {
+        // Sort by category first
+        const categoryOrder = ['navigation', 'action', 'search', 'settings'];
+        const aIndex = categoryOrder.indexOf(a.category);
+        const bIndex = categoryOrder.indexOf(b.category);
+        if (aIndex !== bIndex) {
+          return aIndex - bIndex;
+        }
+        // Then sort alphabetically by title within category
+        return a.title.localeCompare(b.title);
+      });
     
     this.availableCommandsCache = available;
     this.availableCacheTimestamp = Date.now();
@@ -135,21 +145,31 @@ class CommandRegistry {
     }
 
     const availableCommands = this.getAvailableCommands();
-    const scored: Array<{ command: Command; score: number }> = [];
+    const exactMatches: Command[] = [];
+    const startsWithMatches: Command[] = [];
+    const fuzzyMatches: Array<{ command: Command; score: number }> = [];
     
     // Use pre-computed search index
     for (const command of availableCommands) {
       const index = this.searchIndex.get(command.id);
       if (!index) continue;
       
+      // Check for exact match
+      if (index.titleLower === normalizedQuery) {
+        exactMatches.push(command);
+        continue;
+      }
+      
+      // Check for starts-with match
+      if (index.titleLower.startsWith(normalizedQuery)) {
+        startsWithMatches.push(command);
+        continue;
+      }
+      
+      // Calculate fuzzy match score
       let score = 0;
       
-      // Exact match gets highest score
-      if (index.titleLower === normalizedQuery) {
-        score = 100;
-      } else if (index.titleLower.startsWith(normalizedQuery)) {
-        score = 80;
-      } else if (index.titleLower.includes(normalizedQuery)) {
+      if (index.titleLower.includes(normalizedQuery)) {
         score = 60;
       } else if (index.descriptionLower.includes(normalizedQuery)) {
         score = 40;
@@ -172,14 +192,25 @@ class CommandRegistry {
       }
 
       if (score > 0) {
-        scored.push({ command, score });
+        fuzzyMatches.push({ command, score });
       }
     }
 
-    // Sort and extract commands
-    const results = scored
-      .sort((a, b) => b.score - a.score)
-      .map(({ command }) => command);
+    // Sort each group
+    exactMatches.sort((a, b) => a.title.localeCompare(b.title));
+    startsWithMatches.sort((a, b) => a.title.localeCompare(b.title));
+    fuzzyMatches.sort((a, b) => {
+      const scoreDiff = b.score - a.score;
+      if (scoreDiff !== 0) return scoreDiff;
+      return a.command.title.localeCompare(b.command.title);
+    });
+
+    // Combine results: exact matches → starts with → fuzzy matches
+    const results = [
+      ...exactMatches,
+      ...startsWithMatches,
+      ...fuzzyMatches.map(({ command }) => command)
+    ];
 
     // Cache the results
     this.searchCache.set(normalizedQuery, {

--- a/apps/frontend/src/pages/Calendar.tsx
+++ b/apps/frontend/src/pages/Calendar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AppLayout } from '@/components/layout';
 import { Button, Modal } from '@/components/ui';
@@ -10,6 +11,7 @@ import { format, addMonths, subMonths } from 'date-fns';
 import { ChevronLeft, ChevronRight, Plus, Settings } from 'lucide-react';
 
 export function Calendar() {
+  const location = useLocation();
   const { t } = useTranslation(['calendar', 'common']);
   const [currentDate, setCurrentDate] = useState(new Date());
   const [isEventFormOpen, setIsEventFormOpen] = useState(false);
@@ -25,6 +27,16 @@ export function Calendar() {
   useEffect(() => {
     loadEvents();
   }, [currentDate]);
+
+  // Handle navigation state from command palette
+  useEffect(() => {
+    const state = location.state as { openAddModal?: boolean } | null;
+    if (state?.openAddModal) {
+      setIsEventFormOpen(true);
+      // Clear the state to prevent reopening on refresh
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state]);
 
   const loadEvents = async () => {
     try {

--- a/apps/frontend/src/pages/Calendar.tsx
+++ b/apps/frontend/src/pages/Calendar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AppLayout } from '@/components/layout';
 import { Button, Modal } from '@/components/ui';
@@ -12,6 +12,7 @@ import { ChevronLeft, ChevronRight, Plus, Settings } from 'lucide-react';
 
 export function Calendar() {
   const location = useLocation();
+  const navigate = useNavigate();
   const { t } = useTranslation(['calendar', 'common']);
   const [currentDate, setCurrentDate] = useState(new Date());
   const [isEventFormOpen, setIsEventFormOpen] = useState(false);
@@ -34,9 +35,12 @@ export function Calendar() {
     if (state?.openAddModal) {
       setIsEventFormOpen(true);
       // Clear the state to prevent reopening on refresh
-      window.history.replaceState({}, document.title);
+      navigate(
+        { pathname: location.pathname, search: location.search, hash: location.hash },
+        { replace: true, state: {} }
+      );
     }
-  }, [location.state]);
+  }, [location.state, navigate]);
 
   const loadEvents = async () => {
     try {

--- a/apps/frontend/src/pages/Goals.tsx
+++ b/apps/frontend/src/pages/Goals.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { AppLayout } from '@/components/layout';
 import { Button, Modal } from '@/components/ui';
 import { goalApi } from '@/lib/goal-api';
@@ -25,6 +26,7 @@ import {
 import { GoalForm } from '@/components/GoalForm';
 
 export function Goals() {
+  const location = useLocation();
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [goals, setGoals] = useState<GoalWithStatus[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -42,6 +44,16 @@ export function Goals() {
   useEffect(() => {
     loadGoals();
   }, [selectedDate, filter]);
+
+  // Handle navigation state from command palette
+  useEffect(() => {
+    const state = location.state as { openAddModal?: boolean } | null;
+    if (state?.openAddModal) {
+      setIsFormOpen(true);
+      // Clear the state to prevent reopening on refresh
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state]);
 
   const loadGoals = async () => {
     try {

--- a/apps/frontend/src/pages/Goals.tsx
+++ b/apps/frontend/src/pages/Goals.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { AppLayout } from '@/components/layout';
 import { Button, Modal } from '@/components/ui';
 import { goalApi } from '@/lib/goal-api';
@@ -27,6 +27,7 @@ import { GoalForm } from '@/components/GoalForm';
 
 export function Goals() {
   const location = useLocation();
+  const navigate = useNavigate();
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [goals, setGoals] = useState<GoalWithStatus[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -51,9 +52,12 @@ export function Goals() {
     if (state?.openAddModal) {
       setIsFormOpen(true);
       // Clear the state to prevent reopening on refresh
-      window.history.replaceState({}, document.title);
+      navigate(
+        { pathname: location.pathname, search: location.search, hash: location.hash },
+        { replace: true, state: {} }
+      );
     }
-  }, [location.state]);
+  }, [location.state, navigate]);
 
   const loadGoals = async () => {
     try {

--- a/apps/frontend/src/pages/Moments.tsx
+++ b/apps/frontend/src/pages/Moments.tsx
@@ -1,20 +1,21 @@
 import { useState, useEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { AppLayout } from '@/components/layout';
-import { Button, Input, Modal } from '../components/ui';
-import { MomentList } from '../components/MomentList';
-import { MomentForm } from '../components/MomentForm';
-import { MomentViewer } from '../components/MomentViewer';
-import { MomentQuickForm } from '../components/MomentQuickForm';
-import { Moment, CreateMomentDto, UpdateMomentDto, MomentPage } from '../types/moment';
-import { momentApi } from '../lib/moment-api';
-import { toast } from '../components/ui/toast';
+import { Button, Input, Modal } from '@/components/ui';
+import { MomentList } from '@/components/MomentList';
+import { MomentForm } from '@/components/MomentForm';
+import { MomentViewer } from '@/components/MomentViewer';
+import { MomentQuickForm } from '@/components/MomentQuickForm';
+import { Moment, CreateMomentDto, UpdateMomentDto, MomentPage } from '@/types/moment';
+import { momentApi } from '@/lib/moment-api';
+import { toast } from '@/components/ui/toast';
 import { Plus, Search, Tag } from 'lucide-react';
 
 const PREVIEW_LENGTH = 100;
 
 export function Moments() {
   const location = useLocation();
+  const navigate = useNavigate();
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -37,16 +38,22 @@ export function Moments() {
   // Handle navigation state from command palette
   useEffect(() => {
     const state = location.state as { openAddModal?: boolean; focusSearch?: boolean } | null;
+    let handled = false;
     if (state?.openAddModal) {
       setIsFormOpen(true);
-      // Clear the state to prevent reopening on refresh
-      window.history.replaceState({}, document.title);
+      handled = true;
     }
     if (state?.focusSearch && searchInputRef.current) {
       searchInputRef.current.focus();
-      window.history.replaceState({}, document.title);
+      handled = true;
     }
-  }, [location.state]);
+    if (handled) {
+      navigate(
+        { pathname: location.pathname, search: location.search, hash: location.hash },
+        { replace: true, state: {} }
+      );
+    }
+  }, [location.state, navigate]);
 
   const loadMoments = async (pageNumber = 0) => {
     try {

--- a/apps/frontend/src/pages/Moments.tsx
+++ b/apps/frontend/src/pages/Moments.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { AppLayout } from '@/components/layout';
 import { Button, Input, Modal } from '../components/ui';
 import { MomentList } from '../components/MomentList';
@@ -13,6 +14,8 @@ import { Plus, Search, Tag } from 'lucide-react';
 const PREVIEW_LENGTH = 100;
 
 export function Moments() {
+  const location = useLocation();
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [selectedMoment, setSelectedMoment] = useState<Moment | null>(null);
@@ -30,6 +33,20 @@ export function Moments() {
     loadMoments();
     loadTags();
   }, [searchQuery, selectedTag]);
+
+  // Handle navigation state from command palette
+  useEffect(() => {
+    const state = location.state as { openAddModal?: boolean; focusSearch?: boolean } | null;
+    if (state?.openAddModal) {
+      setIsFormOpen(true);
+      // Clear the state to prevent reopening on refresh
+      window.history.replaceState({}, document.title);
+    }
+    if (state?.focusSearch && searchInputRef.current) {
+      searchInputRef.current.focus();
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state]);
 
   const loadMoments = async (pageNumber = 0) => {
     try {
@@ -179,6 +196,7 @@ export function Moments() {
             <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
               <Input
+                ref={searchInputRef}
                 placeholder="Search moments..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}

--- a/apps/frontend/src/pages/Notes.tsx
+++ b/apps/frontend/src/pages/Notes.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 import { Plus, Search } from 'lucide-react';
 import { Button, Input, Modal } from '@/components/ui';
 import { AppLayout } from '@/components/layout';
@@ -18,6 +19,8 @@ import {
 
 export function Notes() {
   const { t } = useTranslation(['notes', 'common']);
+  const location = useLocation();
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [notes, setNotes] = useState<Note[]>([]);
   const [tags, setTags] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -69,6 +72,20 @@ export function Notes() {
       setIsLoading(false);
     });
   }, [loadNotes]);
+
+  // Handle navigation state from command palette
+  useEffect(() => {
+    const state = location.state as { openAddModal?: boolean; focusSearch?: boolean } | null;
+    if (state?.openAddModal) {
+      setIsFormOpen(true);
+      // Clear the state to prevent reopening on refresh
+      window.history.replaceState({}, document.title);
+    }
+    if (state?.focusSearch && searchInputRef.current) {
+      searchInputRef.current.focus();
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state]);
 
   const handleCreateNote = async (data: CreateNoteDto) => {
     setIsSubmitting(true);
@@ -206,6 +223,7 @@ export function Notes() {
             <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
               <Input
+                ref={searchInputRef}
                 placeholder={t('searchPlaceholder')}
                 value={searchQuery}
                 onChange={handleSearchChange}

--- a/apps/frontend/src/pages/Notes.tsx
+++ b/apps/frontend/src/pages/Notes.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Plus, Search } from 'lucide-react';
 import { Button, Input, Modal } from '@/components/ui';
 import { AppLayout } from '@/components/layout';
@@ -20,6 +20,7 @@ import {
 export function Notes() {
   const { t } = useTranslation(['notes', 'common']);
   const location = useLocation();
+  const navigate = useNavigate();
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [notes, setNotes] = useState<Note[]>([]);
   const [tags, setTags] = useState<string[]>([]);
@@ -76,16 +77,22 @@ export function Notes() {
   // Handle navigation state from command palette
   useEffect(() => {
     const state = location.state as { openAddModal?: boolean; focusSearch?: boolean } | null;
+    let handled = false;
     if (state?.openAddModal) {
       setIsFormOpen(true);
-      // Clear the state to prevent reopening on refresh
-      window.history.replaceState({}, document.title);
+      handled = true;
     }
     if (state?.focusSearch && searchInputRef.current) {
       searchInputRef.current.focus();
-      window.history.replaceState({}, document.title);
+      handled = true;
     }
-  }, [location.state]);
+    if (handled) {
+      navigate(
+        { pathname: location.pathname, search: location.search, hash: location.hash },
+        { replace: true, state: {} }
+      );
+    }
+  }, [location.state, navigate]);
 
   const handleCreateNote = async (data: CreateNoteDto) => {
     setIsSubmitting(true);
@@ -142,12 +149,10 @@ export function Notes() {
       setNoteToDelete(null);
       setViewingNote(null);
       
-      // Optimistically update notes list
-      setNotes(prevNotes => prevNotes.filter(n => n.id !== noteToDelete.id));
-      
-      // Check if we need to remove any tags from the list
-      const remainingNotes = notes.filter(n => n.id !== noteToDelete.id);
-      const remainingTags = new Set(remainingNotes.flatMap(n => n.tags));
+      // Optimistically update notes list and derive remaining tags from the same snapshot
+      const updatedNotes = notes.filter(n => n.id !== noteToDelete.id);
+      setNotes(updatedNotes);
+      const remainingTags = new Set(updatedNotes.flatMap(n => n.tags));
       const deletedTags = noteToDelete.tags.filter(tag => !remainingTags.has(tag));
       
       // Reload notes to ensure consistency

--- a/apps/frontend/src/pages/Pomodoro.tsx
+++ b/apps/frontend/src/pages/Pomodoro.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { AppLayout } from '@/components/layout';
 import {
   PomodoroTimer,
@@ -18,6 +20,7 @@ import { Card } from '@/components/ui/Card';
 import { Clock } from 'lucide-react';
 
 export function Pomodoro() {
+  const location = useLocation();
   const { data: activeSession, isLoading } = useActiveSession();
   const { data: config } = usePomodoroConfig();
   const createSession = useCreateSession();
@@ -75,6 +78,16 @@ export function Pomodoro() {
   const handleSessionUpdate = () => {
     // Session will be updated via the query invalidation in the hook
   };
+
+  // Handle navigation state from command palette
+  useEffect(() => {
+    const state = location.state as { autoStart?: boolean } | null;
+    if (state?.autoStart && !activeSession && config) {
+      handleCreateSession();
+      // Clear the state to prevent re-starting on refresh
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state, activeSession, config]);
 
   if (isLoading) {
     return (

--- a/apps/frontend/src/pages/Pomodoro.tsx
+++ b/apps/frontend/src/pages/Pomodoro.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { AppLayout } from '@/components/layout';
 import {
   PomodoroTimer,
@@ -21,6 +21,8 @@ import { Clock } from 'lucide-react';
 
 export function Pomodoro() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const autoStartHandled = useRef(false);
   const { data: activeSession, isLoading } = useActiveSession();
   const { data: config } = usePomodoroConfig();
   const createSession = useCreateSession();
@@ -82,12 +84,16 @@ export function Pomodoro() {
   // Handle navigation state from command palette
   useEffect(() => {
     const state = location.state as { autoStart?: boolean } | null;
-    if (state?.autoStart && !activeSession && config) {
+    if (state?.autoStart && !activeSession && config && !autoStartHandled.current) {
+      autoStartHandled.current = true;
       handleCreateSession();
       // Clear the state to prevent re-starting on refresh
-      window.history.replaceState({}, document.title);
+      navigate(
+        { pathname: location.pathname, search: location.search, hash: location.hash },
+        { replace: true, state: {} }
+      );
     }
-  }, [location.state, activeSession, config]);
+  }, [location.state, activeSession, config, navigate]);
 
   if (isLoading) {
     return (

--- a/apps/frontend/src/pages/Todos.tsx
+++ b/apps/frontend/src/pages/Todos.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { todoApi } from '@/lib/todo-api'
 import { Todo, CreateTodoDto, UpdateTodoDto, TodoStatus } from '@/types/todo'
@@ -14,6 +15,8 @@ import { useTranslation } from 'react-i18next'
 
 export function Todos() {
   const queryClient = useQueryClient()
+  const location = useLocation()
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const { t } = useTranslation(['todos', 'common'])
   const [isAddingTodo, setIsAddingTodo] = useState(false)
   const [editingTodo, setEditingTodo] = useState<Todo | null>(null)
@@ -164,6 +167,20 @@ export function Todos() {
     setParentIdForNewTodo(parentId)
     setIsAddingTodo(true)
   }
+
+  // Handle navigation state from command palette
+  useEffect(() => {
+    const state = location.state as { openAddModal?: boolean; focusSearch?: boolean } | null;
+    if (state?.openAddModal) {
+      setIsAddingTodo(true);
+      // Clear the state to prevent reopening on refresh
+      window.history.replaceState({}, document.title);
+    }
+    if (state?.focusSearch && searchInputRef.current) {
+      searchInputRef.current.focus();
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state]);
 
   // Handle Escape key for delete modal
   useEffect(() => {

--- a/apps/frontend/src/pages/Todos.tsx
+++ b/apps/frontend/src/pages/Todos.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { todoApi } from '@/lib/todo-api'
 import { Todo, CreateTodoDto, UpdateTodoDto, TodoStatus } from '@/types/todo'
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next'
 export function Todos() {
   const queryClient = useQueryClient()
   const location = useLocation()
-  const searchInputRef = useRef<HTMLInputElement>(null)
+  const navigate = useNavigate()
   const { t } = useTranslation(['todos', 'common'])
   const [isAddingTodo, setIsAddingTodo] = useState(false)
   const [editingTodo, setEditingTodo] = useState<Todo | null>(null)
@@ -170,17 +170,16 @@ export function Todos() {
 
   // Handle navigation state from command palette
   useEffect(() => {
-    const state = location.state as { openAddModal?: boolean; focusSearch?: boolean } | null;
+    const state = location.state as { openAddModal?: boolean } | null;
     if (state?.openAddModal) {
       setIsAddingTodo(true);
       // Clear the state to prevent reopening on refresh
-      window.history.replaceState({}, document.title);
+      navigate(
+        { pathname: location.pathname, search: location.search, hash: location.hash },
+        { replace: true, state: {} }
+      );
     }
-    if (state?.focusSearch && searchInputRef.current) {
-      searchInputRef.current.focus();
-      window.history.replaceState({}, document.title);
-    }
-  }, [location.state]);
+  }, [location.state, navigate]);
 
   // Handle Escape key for delete modal
   useEffect(() => {

--- a/todo.md
+++ b/todo.md
@@ -11,7 +11,6 @@ This file tracks pending tasks organized by feature.
 ---
 
 ## Common
-- [HIGH] Add command palette feature - Provide keyboard shortcuts to all features and cross-search functionality
 - [LOW] Add Field-Level Encryption - Encrypt sensitive user data at rest using Cloudflare's Web Crypto API (requires Cloudflare Workers runtime)
 
 ## Auth Feature


### PR DESCRIPTION
## Summary
This PR enhances the Command Palette with significant improvements to user experience, accessibility, and reliability:

- ✨ **Command History**: Track and display 5 most frequently used commands with localStorage persistence
- ♿ **Accessibility**: Add Terminal icon button to header and mobile sidebar for easy palette access
- 🔧 **Stability**: Fix modal position stability with fixed height container
- 🔍 **Search**: Improve sorting algorithm (History → Exact → Starts-with → Fuzzy matches)
- ⚡ **Reliability**: Fix command execution across all pages with proper navigation state handling

## Changes Made

### New Features
1. **Command History Tracking** (`useCommandHistory` hook)
   - Stores 5 most recent commands in localStorage
   - Tracks command ID, timestamp, and usage count
   - Displays history section at top of palette when opened

2. **Header Button for Accessibility**
   - Terminal icon button added to header (between language switcher and theme toggle)
   - Tooltip shows "Ctrl+K" keyboard shortcut
   - Mobile sidebar includes prominent command palette button

### Bug Fixes
1. **Modal Position Stability**
   - Fixed height container (`h-[600px] max-h-[80vh]`)
   - Internal scrolling prevents layout shifts
   - Consistent modal positioning regardless of results

2. **Search Sorting Improvements**
   - Clear sorting hierarchy: History → Exact matches → Starts-with → Fuzzy matches
   - Alphabetical sorting within each group
   - Stable, predictable results

3. **Command Execution Reliability**
   - Fixed navigation state handling in Notes, Todos, Moments, Goals, Calendar, and Pomodoro pages
   - Proper handling of `openAddModal` and `focusSearch` states
   - State cleanup to prevent re-triggering on page refresh

## Files Modified
- `apps/frontend/src/hooks/useCommandHistory.ts` (new)
- `apps/frontend/src/contexts/CommandPaletteContext.tsx`
- `apps/frontend/src/components/CommandPalette.tsx`
- `apps/frontend/src/lib/command-registry.ts`
- `apps/frontend/src/components/layout/Header.tsx`
- `apps/frontend/src/components/layout/Sidebar.tsx`
- `apps/frontend/src/pages/Notes.tsx`
- `apps/frontend/src/pages/Todos.tsx`
- `apps/frontend/src/pages/Moments.tsx`
- `apps/frontend/src/pages/Goals.tsx`
- `apps/frontend/src/pages/Calendar.tsx`
- `apps/frontend/src/pages/Pomodoro.tsx`

## Quality Checks
✅ **TypeScript**: All type checks pass
✅ **Linting**: No errors or warnings
✅ **Build**: Successful production build
✅ **Unit Tests**: 109 tests passing

## Test Plan
- [x] Command history persists across sessions
- [x] Header button opens command palette
- [x] Mobile sidebar button works correctly
- [x] Modal maintains stable position during search
- [x] Search results are predictably sorted
- [x] "New Note" command navigates and opens form
- [x] "Search" commands focus input fields
- [x] "Start Pomodoro" auto-starts timer
- [x] All navigation commands work correctly

## Known Issues
- E2E tests have pre-existing configuration issues (not related to this PR)
- Will be addressed in separate PR

## Future Improvements (from code review)
- Standardize storage mechanism (localStorage vs sessionStorage)
- Add user notifications for command failures
- Implement AbortController for search cancellation
- Add input sanitization for XSS protection

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Command Palette accessible from the header and mobile sidebar (Ctrl+K hint).
  - Persistent command history with a History section in results.

- Improvements
  - Smarter, deterministic search ranking and refined result grouping.
  - Larger, more stable palette layout with virtualization for large lists.
  - Navigation-driven actions: open add forms or focus/search on Calendar, Goals, Moments, Notes, Todos; Pomodoro auto-start.

- Documentation
  - TODO updated: removed Command Palette item; added Field-Level Encryption task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->