### PR TITLE
fix: Remove custom tooltip from command palette button

### DIFF
--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -62,15 +62,11 @@ export function Header({ onMenuClick }: HeaderProps) {
             {/* Command Palette Button */}
             <button
               onClick={openCommandPalette}
-              className="p-2 rounded-md text-foreground hover:bg-muted transition-colors group relative"
+              className="p-2 rounded-md text-foreground hover:bg-muted transition-colors"
               aria-label="Open command palette (Ctrl+K)"
               title="Command Palette (Ctrl+K)"
             >
               <Terminal className="h-5 w-5" />
-              {/* Tooltip on hover */}
-              <span className="absolute hidden group-hover:block bottom-full right-0 mb-2 px-2 py-1 text-xs bg-gray-900 dark:bg-gray-700 text-white rounded whitespace-nowrap">
-                Ctrl+K
-              </span>
             </button>
             
             {/* Theme Toggle */}


### PR DESCRIPTION
## Summary
Fixes the command palette button tooltip issue where a white box was appearing above the header (out of viewport).

## Problem
The custom tooltip (`<span>` element) was positioned above the header using `bottom-full`, causing it to appear outside the viewport. This resulted in users seeing only a white border at the top of the screen.

## Solution
- Removed the custom tooltip implementation
- Kept the native `title` attribute which provides proper browser tooltip on hover
- Simplified the button's className by removing unnecessary `group relative` classes

## Changes
- Modified `/apps/frontend/src/components/layout/Header.tsx`
  - Removed custom span tooltip element
  - Simplified button className
  - Kept title and aria-label attributes for accessibility

## Testing
- [x] Hover over command palette button shows native tooltip
- [x] No white box appears at the top of the screen
- [x] Button functionality remains unchanged
- [x] Keyboard shortcut (Ctrl+K) still works

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Simplified the Command Palette button by removing the custom hover tooltip. The button now relies on the browser’s native tooltip via title/aria-label.
  - The explicit “Ctrl+K” hint is no longer shown in the UI, reducing visual clutter and aligning with system tooltip behavior.
  - No changes to functionality or accessibility; the Command Palette behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->