### PR TITLE
fix: Resolve pomodoro feature issues

### DIFF
--- a/apps/backend/src/__tests__/routes/pomodoro.test.ts
+++ b/apps/backend/src/__tests__/routes/pomodoro.test.ts
@@ -279,6 +279,170 @@ describe('Pomodoro Routes', () => {
         empty: true,
       });
     });
+
+    it('should normalize invalid page/size to safe defaults', async () => {
+      const mockedDb = asMockedDb(ctx.db);
+      let selectCallCount = 0;
+      mockedDb.select.mockImplementation(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          // Auth middleware user lookup
+          return { 
+            from: vi.fn().mockReturnThis(), 
+            where: vi.fn().mockReturnThis(), 
+            get: vi.fn().mockResolvedValue({ 
+              id: userId,
+              email: 'test@example.com',
+              username: 'testuser',
+              enabled: true,
+            }) 
+          };
+        } else if (selectCallCount === 2) {
+          // Count query
+          return { 
+            from: vi.fn().mockReturnThis(), 
+            where: vi.fn().mockReturnThis(), 
+            get: vi.fn().mockResolvedValue({ count: 10 }) 
+          };
+        } else {
+          // Sessions query with normalized parameters
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            orderBy: vi.fn().mockReturnThis(),
+            limit: vi.fn((limit) => {
+              // Should use default size of 20 when invalid
+              expect(limit).toBe(20);
+              return { 
+                offset: vi.fn((offset) => {
+                  // Should use page 0 when invalid
+                  expect(offset).toBe(0);
+                  return Promise.resolve([]);
+                })
+              };
+            }),
+          };
+        }
+      });
+
+      const res = await app.request('/pomodoro/sessions?page=foo&size=bar', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${validToken}` },
+      }, ctx.env);
+      
+      expect(res.status).toBe(200);
+      const body = await res.json() as { size: number; number: number };
+      expect(body.size).toBe(20);
+      expect(body.number).toBe(0);
+    });
+
+    it('should cap large size to MAX_SIZE', async () => {
+      const mockedDb = asMockedDb(ctx.db);
+      let selectCallCount = 0;
+      mockedDb.select.mockImplementation(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          // Auth middleware user lookup
+          return { 
+            from: vi.fn().mockReturnThis(), 
+            where: vi.fn().mockReturnThis(), 
+            get: vi.fn().mockResolvedValue({ 
+              id: userId,
+              email: 'test@example.com',
+              username: 'testuser',
+              enabled: true,
+            }) 
+          };
+        } else if (selectCallCount === 2) {
+          // Count query
+          return { 
+            from: vi.fn().mockReturnThis(), 
+            where: vi.fn().mockReturnThis(), 
+            get: vi.fn().mockResolvedValue({ count: 500 }) 
+          };
+        } else {
+          // Sessions query with capped size
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            orderBy: vi.fn().mockReturnThis(),
+            limit: vi.fn((limit) => {
+              // Should cap to MAX_SIZE of 100
+              expect(limit).toBe(100);
+              return { 
+                offset: vi.fn().mockResolvedValue([]) 
+              };
+            }),
+          };
+        }
+      });
+
+      const res = await app.request('/pomodoro/sessions?size=10000', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${validToken}` },
+      }, ctx.env);
+      
+      expect(res.status).toBe(200);
+      const body = await res.json() as { size: number };
+      expect(body.size).toBe(100);
+    });
+
+    it('should handle negative page and zero size gracefully', async () => {
+      const mockedDb = asMockedDb(ctx.db);
+      let selectCallCount = 0;
+      mockedDb.select.mockImplementation(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          // Auth middleware user lookup
+          return { 
+            from: vi.fn().mockReturnThis(), 
+            where: vi.fn().mockReturnThis(), 
+            get: vi.fn().mockResolvedValue({ 
+              id: userId,
+              email: 'test@example.com',
+              username: 'testuser',
+              enabled: true,
+            }) 
+          };
+        } else if (selectCallCount === 2) {
+          // Count query
+          return { 
+            from: vi.fn().mockReturnThis(), 
+            where: vi.fn().mockReturnThis(), 
+            get: vi.fn().mockResolvedValue({ count: 5 }) 
+          };
+        } else {
+          // Sessions query with normalized parameters
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            orderBy: vi.fn().mockReturnThis(),
+            limit: vi.fn((limit) => {
+              // Should use default size when size=0
+              expect(limit).toBe(20);
+              return { 
+                offset: vi.fn((offset) => {
+                  // Should use page 0 when negative
+                  expect(offset).toBe(0);
+                  return Promise.resolve([]);
+                })
+              };
+            }),
+          };
+        }
+      });
+
+      const res = await app.request('/pomodoro/sessions?page=-5&size=0', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${validToken}` },
+      }, ctx.env);
+      
+      expect(res.status).toBe(200);
+      const body = await res.json() as { size: number; number: number; first: boolean };
+      expect(body.size).toBe(20);
+      expect(body.number).toBe(0);
+      expect(body.first).toBe(true);
+    });
   });
 
   describe('GET /pomodoro/sessions/active', () => {

--- a/apps/backend/src/__tests__/routes/pomodoro.test.ts
+++ b/apps/backend/src/__tests__/routes/pomodoro.test.ts
@@ -140,7 +140,41 @@ describe('Pomodoro Routes', () => {
         },
       ];
 
-      setupDbMock({ sessions: mockSessions });
+      // Mock both the count query and the sessions query
+      const mockedDb = asMockedDb(ctx.db);
+      let selectCallCount = 0;
+      mockedDb.select.mockImplementation(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          // Auth middleware user lookup
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            get: vi.fn().mockResolvedValue({
+              id: userId,
+              email: 'test@example.com',
+              username: 'testuser',
+              enabled: true,
+            }),
+          };
+        } else if (selectCallCount === 2) {
+          // Count query
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            get: vi.fn().mockResolvedValue({ count: 2 }),
+          };
+        } else {
+          // Sessions query
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            orderBy: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            offset: vi.fn().mockResolvedValue(mockSessions),
+          };
+        }
+      });
 
       const res = await app.request('/pomodoro/sessions', {
         method: 'GET',
@@ -150,43 +184,73 @@ describe('Pomodoro Routes', () => {
       }, ctx.env);
 
       expect(res.status).toBe(200);
-      const body = await res.json() as PomodoroSessionResponse[];
+      const body = await res.json() as {
+        content: typeof mockSessions;
+        totalElements: number;
+        totalPages: number;
+        size: number;
+        number: number;
+        first: boolean;
+        last: boolean;
+        empty: boolean;
+      };
       
-      expect(Array.isArray(body)).toBe(true);
-      expect(body).toEqual(mockSessions);
+      expect(body).toMatchObject({
+        content: mockSessions,
+        totalElements: 2,
+        totalPages: 1,
+        size: 20,
+        number: 0,
+        first: true,
+        last: true,
+        empty: false,
+      });
     });
 
     it('should handle pagination parameters', async () => {
       const mockedDb = asMockedDb(ctx.db);
-      let callCount = 0;
-      mockedDb.select.mockImplementation(() => ({
-        from: vi.fn().mockReturnThis(),
-        where: vi.fn().mockReturnThis(),
-        get: vi.fn().mockImplementation(() => {
-          callCount++;
-          if (callCount === 1) {
-            // Auth middleware user lookup
-            return Promise.resolve({
+      let selectCallCount = 0;
+      mockedDb.select.mockImplementation(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          // Auth middleware user lookup
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            get: vi.fn().mockResolvedValue({
               id: userId,
               email: 'test@example.com',
               username: 'testuser',
               enabled: true,
-            });
-          }
-        }),
-        orderBy: vi.fn().mockReturnThis(),
-        limit: vi.fn((limit) => {
-          expect(limit).toBe(10);
-          return {
-            offset: vi.fn((offset) => {
-              expect(offset).toBe(10);
-              return Promise.resolve([]);
             }),
           };
-        }),
-      }));
+        } else if (selectCallCount === 2) {
+          // Count query
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            get: vi.fn().mockResolvedValue({ count: 50 }),
+          };
+        } else {
+          // Sessions query with pagination
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            orderBy: vi.fn().mockReturnThis(),
+            limit: vi.fn((limit) => {
+              expect(limit).toBe(10);
+              return {
+                offset: vi.fn((offset) => {
+                  expect(offset).toBe(10);
+                  return Promise.resolve([]);
+                }),
+              };
+            }),
+          };
+        }
+      });
 
-      const res = await app.request('/pomodoro/sessions?limit=10&offset=10', {
+      const res = await app.request('/pomodoro/sessions?page=1&size=10', {
         method: 'GET',
         headers: {
           'Authorization': `Bearer ${validToken}`,
@@ -194,6 +258,26 @@ describe('Pomodoro Routes', () => {
       }, ctx.env);
 
       expect(res.status).toBe(200);
+      const body = await res.json() as {
+        content: unknown[];
+        totalElements: number;
+        totalPages: number;
+        size: number;
+        number: number;
+        first: boolean;
+        last: boolean;
+        empty: boolean;
+      };
+      expect(body).toMatchObject({
+        content: [],
+        totalElements: 50,
+        totalPages: 5,
+        size: 10,
+        number: 1,
+        first: false,
+        last: false,
+        empty: true,
+      });
     });
   });
 

--- a/apps/backend/src/routes/pomodoro.ts
+++ b/apps/backend/src/routes/pomodoro.ts
@@ -60,18 +60,39 @@ const createTaskSchema = z.object({
 app.get('/sessions', async (c) => {
   const db = c.get('db');
   const userId = c.get('userId');
-  const limit = parseInt(c.req.query('limit') || '20');
-  const offset = parseInt(c.req.query('offset') || '0');
+  const page = parseInt(c.req.query('page') || '0');
+  const size = parseInt(c.req.query('size') || '20');
+  const offset = page * size;
   
   try {
+    // Get total count
+    const countResult = await db.select({ count: sql<number>`count(*)` })
+      .from(pomodoroSessions)
+      .where(eq(pomodoroSessions.userId, userId as string))
+      .get();
+    
+    const totalElements = countResult?.count || 0;
+    const totalPages = Math.ceil(totalElements / size);
+    
+    // Get sessions
     const sessions = await db.select()
       .from(pomodoroSessions)
       .where(eq(pomodoroSessions.userId, userId as string))
       .orderBy(desc(pomodoroSessions.createdAt))
-      .limit(limit)
+      .limit(size)
       .offset(offset);
     
-    return c.json(sessions);
+    // Return paginated response
+    return c.json({
+      content: sessions,
+      totalElements,
+      totalPages,
+      size,
+      number: page,
+      first: page === 0,
+      last: page >= totalPages - 1,
+      empty: sessions.length === 0
+    });
   } catch (error) {
     console.error('Get sessions error:', error);
     return c.json(

--- a/apps/backend/src/routes/pomodoro.ts
+++ b/apps/backend/src/routes/pomodoro.ts
@@ -20,11 +20,10 @@ app.use('*', authMiddleware);
 const createSessionSchema = z.object({
   workDuration: z.number().min(1),
   breakDuration: z.number().min(1),
-  sessionType: z.string().optional(),
+  sessionType: z.enum(['WORK', 'SHORT_BREAK', 'LONG_BREAK']).optional(),
   tasks: z.array(z.object({
     todoId: z.number().optional(),
     description: z.string().min(1),
-    orderIndex: z.number(),
   })).optional(),
 });
 
@@ -60,8 +59,20 @@ const createTaskSchema = z.object({
 app.get('/sessions', async (c) => {
   const db = c.get('db');
   const userId = c.get('userId');
-  const page = parseInt(c.req.query('page') || '0');
-  const size = parseInt(c.req.query('size') || '20');
+  
+  // Parse and validate pagination parameters
+  const rawPage = c.req.query('page');
+  const rawSize = c.req.query('size');
+  let page = Number.parseInt(rawPage ?? '0', 10);
+  let size = Number.parseInt(rawSize ?? '20', 10);
+  
+  // Normalize invalid values
+  if (!Number.isFinite(page) || page < 0) page = 0;
+  
+  const MAX_SIZE = 100;
+  if (!Number.isFinite(size) || size <= 0) size = 20;
+  if (size > MAX_SIZE) size = MAX_SIZE;
+  
   const offset = page * size;
   
   try {
@@ -72,7 +83,7 @@ app.get('/sessions', async (c) => {
       .get();
     
     const totalElements = countResult?.count || 0;
-    const totalPages = Math.ceil(totalElements / size);
+    const totalPages = size > 0 ? Math.ceil(totalElements / size) : 0;
     
     // Get sessions
     const sessions = await db.select()
@@ -90,7 +101,7 @@ app.get('/sessions', async (c) => {
       size,
       number: page,
       first: page === 0,
-      last: page >= totalPages - 1,
+      last: totalPages === 0 ? true : page >= totalPages - 1,
       empty: sessions.length === 0
     });
   } catch (error) {
@@ -221,12 +232,12 @@ app.post('/sessions', zValidator('json', createSessionSchema, springBootValidato
     
     // Create tasks if provided
     if (data.tasks && data.tasks.length > 0) {
-      const taskValues = data.tasks.map((task: { todoId?: number; description: string; orderIndex: number }) => ({
+      const taskValues = data.tasks.map((task: { todoId?: number; description: string }, idx: number) => ({
         id: nanoid(),
         sessionId,
         todoId: task.todoId,
         description: task.description,
-        orderIndex: task.orderIndex,
+        orderIndex: idx,
         completed: false,
         createdAt: now,
         updatedAt: now,

--- a/apps/frontend/src/pages/Pomodoro.tsx
+++ b/apps/frontend/src/pages/Pomodoro.tsx
@@ -13,7 +13,7 @@ import {
   usePomodoroConfig,
   useUpdateSession,
 } from '@/hooks/usePomodoro';
-import { SessionAction, SessionType } from '@/types/pomodoro';
+import { PomodoroSession, SessionAction, SessionStatus, SessionType } from '@/types/pomodoro';
 import { prepareSessionData, getIncompleteTasks } from '@/utils/pomodoroHelpers';
 import { Button } from '@/components/ui';
 import { Card } from '@/components/ui/Card';
@@ -31,54 +31,77 @@ export function Pomodoro() {
   // Tasks from active session
   const tasks = activeSession?.tasks || [];
 
-  const handleCreateSession = (initialTask?: string) => {
+  const handleCreateSession = (initialTask?: string, sessionType: string = 'WORK') => {
     if (!config) return;
 
-    const sessionData = prepareSessionData(config, initialTask, tasks);
+    const sessionData = prepareSessionData(config, initialTask, tasks, sessionType);
 
     createSession.mutate(sessionData);
   };
 
-  const handleSessionComplete = () => {
-    // Check if we should auto-start break
-    if (!activeSession || !config) return;
+  const handleSessionComplete = (completedSession?: PomodoroSession) => {
+    // Check if we should auto-start break or work
+    const session = completedSession || activeSession;
+    if (!session || !config) return;
 
-    if (activeSession.sessionType === 'WORK' && config.autoStartBreaks) {
-      // Determine break type
-      const isLongBreak = (activeSession.completedCycles + 1) % config.cyclesBeforeLongBreak === 0;
+    if (session.sessionType === 'WORK' && config.autoStartBreaks) {
+      // Determine break type based on completed cycles
+      // The session has been marked as completed by PomodoroTimer, so cycles are already updated
+      const isLongBreak = session.completedCycles % config.cyclesBeforeLongBreak === 0;
       const breakDuration = isLongBreak ? config.longBreakDuration : config.shortBreakDuration;
+      const breakType = isLongBreak ? SessionType.LONG_BREAK : SessionType.SHORT_BREAK;
 
-      // Create break session after a short delay
+      // Create and auto-start break session after a short delay
       setTimeout(() => {
-        // Create session with incomplete tasks carried over
         const breakSessionData = {
           workDuration: config.workDuration,
           breakDuration: breakDuration,
+          sessionType: breakType,
           tasks: getIncompleteTasks(tasks),
         };
 
         createSession.mutate(breakSessionData, {
           onSuccess: (newSession) => {
-            // Switch to break type after creation
-            const breakType = isLongBreak ? SessionType.LONG_BREAK : SessionType.SHORT_BREAK;
-            updateSession.mutate({
-              id: newSession.id,
-              action: SessionAction.SWITCH_TYPE,
-              sessionType: breakType,
-            });
+            // Auto-start the break session
+            setTimeout(() => {
+              updateSession.mutate({
+                id: newSession.id,
+                action: SessionAction.START,
+              });
+            }, 500);
           },
         });
       }, 1000);
-    } else if (activeSession.sessionType !== 'WORK' && config.autoStartWork) {
+    } else if (session.sessionType !== 'WORK' && config.autoStartWork) {
       // Auto-start work session after break
       setTimeout(() => {
-        handleCreateSession();
+        const workSessionData = {
+          workDuration: config.workDuration,
+          breakDuration: config.shortBreakDuration,
+          sessionType: SessionType.WORK,
+          tasks: getIncompleteTasks(tasks),
+        };
+
+        createSession.mutate(workSessionData, {
+          onSuccess: (newSession) => {
+            // Auto-start the work session
+            setTimeout(() => {
+              updateSession.mutate({
+                id: newSession.id,
+                action: SessionAction.START,
+              });
+            }, 500);
+          },
+        });
       }, 1000);
     }
   };
 
-  const handleSessionUpdate = () => {
-    // Session will be updated via the query invalidation in the hook
+  const handleSessionUpdate = (updatedSession: PomodoroSession) => {
+    // If session was just completed, pass the updated session to complete handler
+    if (updatedSession.status === SessionStatus.COMPLETED) {
+      handleSessionComplete(updatedSession);
+    }
   };
 
   // Handle navigation state from command palette
@@ -127,7 +150,7 @@ export function Pomodoro() {
             {activeSession ? (
               <PomodoroTimer
                 session={activeSession}
-                onComplete={handleSessionComplete}
+                onComplete={() => {}}
                 onUpdate={handleSessionUpdate}
               />
             ) : (

--- a/apps/frontend/src/pages/Pomodoro.tsx
+++ b/apps/frontend/src/pages/Pomodoro.tsx
@@ -31,7 +31,7 @@ export function Pomodoro() {
   // Tasks from active session
   const tasks = activeSession?.tasks || [];
 
-  const handleCreateSession = (initialTask?: string, sessionType: string = 'WORK') => {
+  const handleCreateSession = (initialTask?: string, sessionType: SessionType = SessionType.WORK) => {
     if (!config) return;
 
     const sessionData = prepareSessionData(config, initialTask, tasks, sessionType);
@@ -62,13 +62,11 @@ export function Pomodoro() {
 
         createSession.mutate(breakSessionData, {
           onSuccess: (newSession) => {
-            // Auto-start the break session
-            setTimeout(() => {
-              updateSession.mutate({
-                id: newSession.id,
-                action: SessionAction.START,
-              });
-            }, 500);
+            // Auto-start the break session immediately
+            updateSession.mutate({
+              id: newSession.id,
+              action: SessionAction.START,
+            });
           },
         });
       }, 1000);
@@ -84,13 +82,11 @@ export function Pomodoro() {
 
         createSession.mutate(workSessionData, {
           onSuccess: (newSession) => {
-            // Auto-start the work session
-            setTimeout(() => {
-              updateSession.mutate({
-                id: newSession.id,
-                action: SessionAction.START,
-              });
-            }, 500);
+            // Auto-start the work session immediately
+            updateSession.mutate({
+              id: newSession.id,
+              action: SessionAction.START,
+            });
           },
         });
       }, 1000);

--- a/apps/frontend/src/types/pomodoro.ts
+++ b/apps/frontend/src/types/pomodoro.ts
@@ -52,6 +52,7 @@ export interface PomodoroConfig {
 export interface CreatePomodoroSessionRequest {
   workDuration: number;
   breakDuration: number;
+  sessionType?: string;
   tasks?: CreatePomodoroTaskRequest[];
 }
 

--- a/apps/frontend/src/types/pomodoro.ts
+++ b/apps/frontend/src/types/pomodoro.ts
@@ -52,7 +52,7 @@ export interface PomodoroConfig {
 export interface CreatePomodoroSessionRequest {
   workDuration: number;
   breakDuration: number;
-  sessionType?: string;
+  sessionType?: SessionType;
   tasks?: CreatePomodoroTaskRequest[];
 }
 

--- a/apps/frontend/src/utils/pomodoroHelpers.ts
+++ b/apps/frontend/src/utils/pomodoroHelpers.ts
@@ -1,10 +1,10 @@
-import { PomodoroConfig, PomodoroTask, CreatePomodoroTaskRequest, CreatePomodoroSessionRequest } from '@/types/pomodoro';
+import { PomodoroConfig, PomodoroTask, CreatePomodoroTaskRequest, CreatePomodoroSessionRequest, SessionType } from '@/types/pomodoro';
 
 export function prepareSessionData(
   config: PomodoroConfig,
   initialTask?: string,
   currentTasks?: PomodoroTask[],
-  sessionType: string = 'WORK'
+  sessionType: SessionType = SessionType.WORK
 ): CreatePomodoroSessionRequest {
   const tasks: CreatePomodoroTaskRequest[] = [];
   
@@ -21,7 +21,9 @@ export function prepareSessionData(
   
   return {
     workDuration: config.workDuration,
-    breakDuration: config.shortBreakDuration,
+    breakDuration: sessionType === SessionType.LONG_BREAK 
+      ? config.longBreakDuration 
+      : config.shortBreakDuration,
     sessionType,
     tasks
   };

--- a/apps/frontend/src/utils/pomodoroHelpers.ts
+++ b/apps/frontend/src/utils/pomodoroHelpers.ts
@@ -3,7 +3,8 @@ import { PomodoroConfig, PomodoroTask, CreatePomodoroTaskRequest, CreatePomodoro
 export function prepareSessionData(
   config: PomodoroConfig,
   initialTask?: string,
-  currentTasks?: PomodoroTask[]
+  currentTasks?: PomodoroTask[],
+  sessionType: string = 'WORK'
 ): CreatePomodoroSessionRequest {
   const tasks: CreatePomodoroTaskRequest[] = [];
   
@@ -21,6 +22,7 @@ export function prepareSessionData(
   return {
     workDuration: config.workDuration,
     breakDuration: config.shortBreakDuration,
+    sessionType,
     tasks
   };
 }


### PR DESCRIPTION
## Summary
- Fixed pagination for session history to properly display past sessions
- Fixed automatic work session starting after breaks
- Fixed session type handling during creation

## Changes Made
- Backend `/api/v1/pomodoro/sessions` now returns paginated response format
- Frontend properly sets session type when creating new sessions
- Automatic session transitions between work/break now use updated session data
- Tests updated to match new response format

## Test Plan
- [x] All unit tests pass
- [x] TypeScript type checking passes
- [x] Linting passes
- [x] Build succeeds
- [x] Manual testing of pomodoro features

## Issues Fixed
- History not displaying properly (404 error resolved)
- Work sessions not auto-starting after breaks
- Session types not properly set during creation

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Sessions list now paginated (page/size) with totals, sensible defaults and size limits for reliable navigation.
  - Sessions can include an explicit session type (work/short/long break) and carry over incomplete tasks.
  - Automatic start of the next break or work session based on user settings and session state.

- Refactor
  - Completion flow reorganized to use update-driven transitions for smoother, more reliable session handoffs.

- Tests
  - Expanded tests for pagination, edge cases, and parameter normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->