### PR TITLE
feat: Add keyboard shortcuts for moment tag selection

### DIFF
--- a/apps/frontend/src/components/MomentForm.tsx
+++ b/apps/frontend/src/components/MomentForm.tsx
@@ -7,6 +7,7 @@ import { X, Plus, Tag } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { validateTagsLength, getSerializedTagsLength, MAX_TAGS_LENGTH } from '@/lib/tag-utils';
 import { getTagColorClasses } from '@/utils/momentUtils';
+import { useMomentTagKeyboardShortcuts } from '@/hooks/useMomentTagKeyboardShortcuts';
 
 interface MomentFormProps {
   isOpen: boolean;
@@ -22,6 +23,24 @@ export function MomentForm({ isOpen, onClose, onSubmit, moment, isSubmitting }: 
   const [currentTag, setCurrentTag] = useState('');
   const [showCustomTagInput, setShowCustomTagInput] = useState(false);
   const [, setErrors] = useState<{ content?: string }>({});
+
+  const toggleTag = (tag: string) => {
+    if (tags.includes(tag)) {
+      setTags(tags.filter(t => t !== tag));
+    } else {
+      const newTags = [...tags, tag];
+      if (!validateTagsLength(newTags)) {
+        // Optionally show an error message here
+        return;
+      }
+      setTags(newTags);
+    }
+  };
+
+  const tagShortcuts = useMomentTagKeyboardShortcuts({
+    onToggleTag: toggleTag,
+    isEnabled: isOpen,
+  });
 
   useEffect(() => {
     if (moment) {
@@ -62,19 +81,6 @@ export function MomentForm({ isOpen, onClose, onSubmit, moment, isSubmitting }: 
     };
 
     onSubmit(data);
-  };
-
-  const toggleTag = (tag: string) => {
-    if (tags.includes(tag)) {
-      setTags(tags.filter(t => t !== tag));
-    } else {
-      const newTags = [...tags, tag];
-      if (!validateTagsLength(newTags)) {
-        // Optionally show an error message here
-        return;
-      }
-      setTags(newTags);
-    }
   };
 
   const addCustomTag = () => {
@@ -133,23 +139,32 @@ export function MomentForm({ isOpen, onClose, onSubmit, moment, isSubmitting }: 
           </label>
           
           <div className="flex flex-wrap gap-2 mb-3">
-            {DEFAULT_MOMENT_TAGS.map((tag) => (
-              <button
-                key={tag}
-                type="button"
-                onClick={() => toggleTag(tag)}
-                aria-pressed={tags.includes(tag)}
-                className={cn(
-                  'inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors',
-                  tags.includes(tag)
-                    ? `${getTagColorClasses(tag)} ring-2 ring-offset-2 ring-offset-white dark:ring-offset-gray-800`
-                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
-                )}
-              >
-                <Tag className="w-3 h-3" />
-                {tag}
-              </button>
-            ))}
+            {DEFAULT_MOMENT_TAGS.map((tag) => {
+              const shortcutKey = Object.keys(tagShortcuts).find(key => tagShortcuts[key] === tag);
+              return (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => toggleTag(tag)}
+                  aria-pressed={tags.includes(tag)}
+                  title={shortcutKey ? `Press Shift+${shortcutKey} to toggle` : undefined}
+                  className={cn(
+                    'inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors relative group',
+                    tags.includes(tag)
+                      ? `${getTagColorClasses(tag)} ring-2 ring-offset-2 ring-offset-white dark:ring-offset-gray-800`
+                      : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                  )}
+                >
+                  <Tag className="w-3 h-3" />
+                  {tag}
+                  {shortcutKey && (
+                    <kbd className="ml-1 text-xs opacity-60 font-mono">
+                      ⇧{shortcutKey}
+                    </kbd>
+                  )}
+                </button>
+              );
+            })}
           </div>
 
           {tags.filter(tag => !(DEFAULT_MOMENT_TAGS as readonly string[]).includes(tag)).length > 0 && (

--- a/apps/frontend/src/components/MomentForm.tsx
+++ b/apps/frontend/src/components/MomentForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Moment, CreateMomentDto, UpdateMomentDto, DEFAULT_MOMENT_TAGS } from '@/types/moment';
 import { Modal } from '@/components/ui/Modal';
 import { Button } from '@/components/ui/Button';
@@ -24,23 +24,29 @@ export function MomentForm({ isOpen, onClose, onSubmit, moment, isSubmitting }: 
   const [showCustomTagInput, setShowCustomTagInput] = useState(false);
   const [, setErrors] = useState<{ content?: string }>({});
 
-  const toggleTag = (tag: string) => {
-    if (tags.includes(tag)) {
-      setTags(tags.filter(t => t !== tag));
-    } else {
-      const newTags = [...tags, tag];
-      if (!validateTagsLength(newTags)) {
+  const toggleTag = useCallback((tag: string) => {
+    setTags(prev => {
+      const next = prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag];
+      if (!validateTagsLength(next)) {
         // Optionally show an error message here
-        return;
+        return prev; // no-op if exceeding limit
       }
-      setTags(newTags);
-    }
-  };
+      return next;
+    });
+  }, []);
 
   const tagShortcuts = useMomentTagKeyboardShortcuts({
     onToggleTag: toggleTag,
     isEnabled: isOpen,
   });
+
+  // Precompute inverse mapping for performance
+  const keyForTag = useMemo(() => {
+    return Object.entries(tagShortcuts).reduce<Record<string, string>>((acc, [key, tag]) => {
+      acc[tag] = key;
+      return acc;
+    }, {});
+  }, [tagShortcuts]);
 
   useEffect(() => {
     if (moment) {
@@ -140,7 +146,7 @@ export function MomentForm({ isOpen, onClose, onSubmit, moment, isSubmitting }: 
           
           <div className="flex flex-wrap gap-2 mb-3">
             {DEFAULT_MOMENT_TAGS.map((tag) => {
-              const shortcutKey = Object.keys(tagShortcuts).find(key => tagShortcuts[key] === tag);
+              const shortcutKey = keyForTag[tag];
               return (
                 <button
                   key={tag}

--- a/apps/frontend/src/components/MomentQuickForm.tsx
+++ b/apps/frontend/src/components/MomentQuickForm.tsx
@@ -3,6 +3,7 @@ import { Button } from './ui'
 import { CreateMomentDto, DEFAULT_MOMENT_TAGS } from '../types/moment'
 import { Send, Tag, Hash } from 'lucide-react'
 import { getTagColorClasses } from '@/utils/momentUtils'
+import { useMomentTagKeyboardShortcuts } from '@/hooks/useMomentTagKeyboardShortcuts'
 
 interface MomentQuickFormProps {
   onSubmit: (data: CreateMomentDto) => void
@@ -22,6 +23,11 @@ export function MomentQuickForm({ onSubmit, isSubmitting }: MomentQuickFormProps
         : [...prev, tag]
     )
   }
+
+  const tagShortcuts = useMomentTagKeyboardShortcuts({
+    onToggleTag: toggleTag,
+    isEnabled: true,
+  })
 
   const handleAddCustomTag = () => {
     if (!customTag) return
@@ -77,12 +83,14 @@ export function MomentQuickForm({ onSubmit, isSubmitting }: MomentQuickFormProps
             {DEFAULT_MOMENT_TAGS.map((tag) => {
               const isSelected = tags.includes(tag)
               const tagColorClass = getTagColorClasses(tag)
+              const shortcutKey = Object.keys(tagShortcuts).find(key => tagShortcuts[key] === tag)
               return (
                 <button
                   key={tag}
                   type="button"
                   onClick={() => toggleTag(tag)}
                   aria-pressed={isSelected}
+                  title={shortcutKey ? `Press Shift+${shortcutKey} to toggle` : undefined}
                   className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium transition-all ${
                     isSelected 
                       ? `${tagColorClass} ring-2 ring-offset-2 ring-offset-background` 
@@ -91,6 +99,11 @@ export function MomentQuickForm({ onSubmit, isSubmitting }: MomentQuickFormProps
                 >
                   <Tag className="w-3 h-3" />
                   {tag}
+                  {shortcutKey && (
+                    <kbd className="ml-1 text-[10px] opacity-60 font-mono">
+                      ⇧{shortcutKey}
+                    </kbd>
+                  )}
                 </button>
               )
             })}

--- a/apps/frontend/src/components/MomentQuickForm.tsx
+++ b/apps/frontend/src/components/MomentQuickForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import { Button } from './ui'
 import { CreateMomentDto, DEFAULT_MOMENT_TAGS } from '../types/moment'
 import { Send, Tag, Hash } from 'lucide-react'
@@ -16,18 +16,26 @@ export function MomentQuickForm({ onSubmit, isSubmitting }: MomentQuickFormProps
   const [customTag, setCustomTag] = useState('')
   const [showCustomTagInput, setShowCustomTagInput] = useState(false)
 
-  const toggleTag = (tag: string) => {
+  const toggleTag = useCallback((tag: string) => {
     setTags(prev => 
       prev.includes(tag) 
         ? prev.filter(t => t !== tag)
         : [...prev, tag]
     )
-  }
+  }, [])
 
   const tagShortcuts = useMomentTagKeyboardShortcuts({
     onToggleTag: toggleTag,
     isEnabled: true,
   })
+
+  // Precompute inverse mapping for performance
+  const keyForTag = useMemo(() => {
+    return Object.entries(tagShortcuts).reduce<Record<string, string>>((acc, [key, tag]) => {
+      acc[tag] = key;
+      return acc;
+    }, {});
+  }, [tagShortcuts])
 
   const handleAddCustomTag = () => {
     if (!customTag) return
@@ -83,7 +91,7 @@ export function MomentQuickForm({ onSubmit, isSubmitting }: MomentQuickFormProps
             {DEFAULT_MOMENT_TAGS.map((tag) => {
               const isSelected = tags.includes(tag)
               const tagColorClass = getTagColorClasses(tag)
-              const shortcutKey = Object.keys(tagShortcuts).find(key => tagShortcuts[key] === tag)
+              const shortcutKey = keyForTag[tag]
               return (
                 <button
                   key={tag}

--- a/apps/frontend/src/hooks/useMomentTagKeyboardShortcuts.ts
+++ b/apps/frontend/src/hooks/useMomentTagKeyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { DEFAULT_MOMENT_TAGS } from '@/types/moment';
 
 interface UseMomentTagKeyboardShortcutsProps {
@@ -6,7 +6,10 @@ interface UseMomentTagKeyboardShortcutsProps {
   isEnabled?: boolean;
 }
 
-const TAG_SHORTCUTS: Record<string, string> = {
+type TagShortcutKey = 'F1' | 'F2' | 'F3' | 'F4' | 'F5';
+type DefaultTag = typeof DEFAULT_MOMENT_TAGS[number];
+
+const TAG_SHORTCUTS: Record<TagShortcutKey, DefaultTag> = {
   F1: DEFAULT_MOMENT_TAGS[0], // Ideas
   F2: DEFAULT_MOMENT_TAGS[1], // Discoveries
   F3: DEFAULT_MOMENT_TAGS[2], // Emotions
@@ -18,14 +21,21 @@ export function useMomentTagKeyboardShortcuts({
   onToggleTag,
   isEnabled = true,
 }: UseMomentTagKeyboardShortcutsProps) {
+  // Store the callback in a ref to avoid re-binding the event listener
+  const onToggleTagRef = useRef(onToggleTag);
+  useEffect(() => {
+    onToggleTagRef.current = onToggleTag;
+  }, [onToggleTag]);
+
   useEffect(() => {
     if (!isEnabled) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
       // Check if Shift key is pressed and the key is a function key
-      if (event.shiftKey && TAG_SHORTCUTS[event.key]) {
+      if (event.shiftKey && TAG_SHORTCUTS[event.key as TagShortcutKey]) {
         event.preventDefault();
-        onToggleTag(TAG_SHORTCUTS[event.key]);
+        const tag = TAG_SHORTCUTS[event.key as TagShortcutKey];
+        onToggleTagRef.current(tag);
       }
     };
 
@@ -34,7 +44,7 @@ export function useMomentTagKeyboardShortcuts({
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [onToggleTag, isEnabled]);
+  }, [isEnabled]); // Only depend on isEnabled, not onToggleTag
 
-  return TAG_SHORTCUTS;
+  return TAG_SHORTCUTS as Record<string, string>; // Cast back for backward compatibility
 }

--- a/apps/frontend/src/hooks/useMomentTagKeyboardShortcuts.ts
+++ b/apps/frontend/src/hooks/useMomentTagKeyboardShortcuts.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { DEFAULT_MOMENT_TAGS } from '@/types/moment';
+
+interface UseMomentTagKeyboardShortcutsProps {
+  onToggleTag: (tag: string) => void;
+  isEnabled?: boolean;
+}
+
+const TAG_SHORTCUTS: Record<string, string> = {
+  F1: DEFAULT_MOMENT_TAGS[0], // Ideas
+  F2: DEFAULT_MOMENT_TAGS[1], // Discoveries
+  F3: DEFAULT_MOMENT_TAGS[2], // Emotions
+  F4: DEFAULT_MOMENT_TAGS[3], // Log
+  F5: DEFAULT_MOMENT_TAGS[4], // Other
+};
+
+export function useMomentTagKeyboardShortcuts({
+  onToggleTag,
+  isEnabled = true,
+}: UseMomentTagKeyboardShortcutsProps) {
+  useEffect(() => {
+    if (!isEnabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Check if Shift key is pressed and the key is a function key
+      if (event.shiftKey && TAG_SHORTCUTS[event.key]) {
+        event.preventDefault();
+        onToggleTag(TAG_SHORTCUTS[event.key]);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onToggleTag, isEnabled]);
+
+  return TAG_SHORTCUTS;
+}

--- a/todo.md
+++ b/todo.md
@@ -26,7 +26,6 @@ This file tracks pending tasks organized by feature.
 ## Goals Feature
 
 ## Moments Feature
-- [MEDIUM] Add keyboard shortcuts for moment tag selection - Enable Shift+F1-F12 shortcuts for quick tag selection
 
 ## Pomodoro Feature
 


### PR DESCRIPTION
## Summary
- Implement keyboard shortcuts (Shift+F1 through Shift+F5) for quick moment tag selection
- Add visual indicators showing keyboard shortcuts next to each tag button
- Create reusable React hook for managing keyboard event handling

## Changes
- **New Hook**: Created `useMomentTagKeyboardShortcuts` hook to handle keyboard events
  - Maps Shift+F1 to "Ideas", Shift+F2 to "Discoveries", etc.
  - Includes proper cleanup of event listeners
  - Supports conditional enabling/disabling
  
- **UI Updates**: Enhanced `MomentForm` and `MomentQuickForm` components
  - Display keyboard shortcut hints (⇧F1-F5) next to tag buttons
  - Integrate keyboard shortcut functionality seamlessly
  - Maintain existing click functionality

## Test Plan
- [x] Verify Shift+F1 through Shift+F5 toggle respective tags
- [x] Confirm visual hints are displayed correctly
- [x] Test that shortcuts work in both MomentForm and MomentQuickForm
- [x] Ensure shortcuts are disabled when forms are closed
- [x] Verify no conflicts with existing keyboard shortcuts
- [x] Run lint and type checks - all passing
- [x] Run unit tests - all passing
- [x] Build verification - successful

## Screenshots
Keyboard shortcut hints are now visible next to each tag:
- Ideas ⇧F1
- Discoveries ⇧F2
- Emotions ⇧F3
- Log ⇧F4
- Other ⇧F5

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Shift+F1–F5 keyboard shortcuts to quickly toggle default tags in MomentForm and MomentQuickForm; shortcuts show per-tag hints and tooltip text (e.g., “Press Shift+F2 to toggle”).
  * Shortcuts are active only when the relevant form/modal is enabled, and existing tag add/remove behavior is unchanged.

* **Documentation**
  * Removed the TODO entry for adding keyboard shortcuts to moment tag selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->