### PR TITLE
fix: Improve Pomodoro feature UX and fix critical issues

### DIFF
--- a/apps/backend/migrations/0003_add_carry_over_tasks_config.sql
+++ b/apps/backend/migrations/0003_add_carry_over_tasks_config.sql
@@ -1,0 +1,6 @@
+-- Add carryOverIncompleteTasks and soundEnabled fields to pomodoro_configs table
+ALTER TABLE pomodoro_configs 
+ADD COLUMN carry_over_incomplete_tasks INTEGER DEFAULT 1 NOT NULL;
+
+ALTER TABLE pomodoro_configs
+ADD COLUMN sound_enabled INTEGER DEFAULT 1 NOT NULL;

--- a/apps/backend/migrations/0004_add_pending_status.sql
+++ b/apps/backend/migrations/0004_add_pending_status.sql
@@ -1,0 +1,4 @@
+-- Add PENDING status to pomodoro_sessions
+-- SQLite doesn't support ALTER COLUMN, so we need to recreate the table or use a workaround
+-- Since this is a CHECK constraint issue, we'll just document that PENDING is now a valid value
+-- The application code will handle this new status value

--- a/apps/backend/src/__tests__/routes/pomodoro.test.ts
+++ b/apps/backend/src/__tests__/routes/pomodoro.test.ts
@@ -164,7 +164,7 @@ describe('Pomodoro Routes', () => {
             where: vi.fn().mockReturnThis(),
             get: vi.fn().mockResolvedValue({ count: 2 }),
           };
-        } else {
+        } else if (selectCallCount === 3) {
           // Sessions query
           return {
             from: vi.fn().mockReturnThis(),
@@ -172,6 +172,13 @@ describe('Pomodoro Routes', () => {
             orderBy: vi.fn().mockReturnThis(),
             limit: vi.fn().mockReturnThis(),
             offset: vi.fn().mockResolvedValue(mockSessions),
+          };
+        } else {
+          // Tasks query for sessions
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            orderBy: vi.fn().mockResolvedValue([]), // Return empty array for tasks
           };
         }
       });
@@ -196,7 +203,7 @@ describe('Pomodoro Routes', () => {
       };
       
       expect(body).toMatchObject({
-        content: mockSessions,
+        content: mockSessions.map(session => ({ ...session, tasks: [] })),
         totalElements: 2,
         totalPages: 1,
         size: 20,
@@ -660,7 +667,7 @@ describe('Pomodoro Routes', () => {
       expect(body.id).toBeDefined();
       expect(body.workDuration).toBe(25);
       expect(body.breakDuration).toBe(5);
-      expect(body.status).toBe('ACTIVE');
+      expect(body.status).toBe('PAUSED');
       
       // Verify tasks were created with the correct data
       expect(body.tasks).toBeDefined();

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -118,7 +118,7 @@ export const pomodoroSessions = sqliteTable('pomodoro_sessions', {
   workDuration: integer('work_duration').notNull(),
   breakDuration: integer('break_duration').notNull(),
   completedCycles: integer('completed_cycles').default(0).notNull(),
-  status: text('status', { enum: ['ACTIVE', 'PAUSED', 'COMPLETED', 'CANCELLED'] }).notNull(),
+  status: text('status', { enum: ['PENDING', 'ACTIVE', 'PAUSED', 'COMPLETED', 'CANCELLED'] }).notNull(),
   sessionType: text('session_type'),
   createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`).notNull(),
   updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`).notNull(),

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -146,8 +146,10 @@ export const pomodoroConfigs = sqliteTable('pomodoro_configs', {
   cyclesBeforeLongBreak: integer('cycles_before_long_break').default(4).notNull(),
   alarmSound: text('alarm_sound').default('default').notNull(),
   alarmVolume: integer('alarm_volume').default(50).notNull(),
+  soundEnabled: integer('sound_enabled', { mode: 'boolean' }).default(true).notNull(),
   autoStartBreaks: integer('auto_start_breaks', { mode: 'boolean' }).default(true).notNull(),
   autoStartWork: integer('auto_start_work', { mode: 'boolean' }).default(false).notNull(),
+  carryOverIncompleteTasks: integer('carry_over_incomplete_tasks', { mode: 'boolean' }).default(true).notNull(),
   createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`).notNull(),
   updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`).notNull(),
 });

--- a/apps/backend/src/routes/pomodoro.ts
+++ b/apps/backend/src/routes/pomodoro.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
-import { eq, and, desc, sql } from 'drizzle-orm';
+import { eq, and, desc, sql, inArray } from 'drizzle-orm';
 import { pomodoroSessions, pomodoroTasks, pomodoroConfigs } from '../db/schema';
 import type { Bindings, Variables } from '../types';
 import { authMiddleware } from '../middleware/auth';
@@ -95,16 +95,24 @@ app.get('/sessions', async (c) => {
       .limit(size)
       .offset(offset);
     
-    // Get tasks for each session
-    const sessionsWithTasks = await Promise.all(
-      sessions.map(async (session) => {
-        const tasks = await db.select()
-          .from(pomodoroTasks)
-          .where(eq(pomodoroTasks.sessionId, session.id))
-          .orderBy(pomodoroTasks.orderIndex);
-        return { ...session, tasks };
-      })
-    );
+    // Get tasks for all sessions in a single query to avoid N+1
+    const sessionIds = sessions.map((s) => s.id);
+    type TaskType = typeof pomodoroTasks.$inferSelect;
+    let tasksBySession: Record<string, TaskType[]> = {};
+    if (sessionIds.length > 0) {
+      const allTasks = await db.select()
+        .from(pomodoroTasks)
+        .where(inArray(pomodoroTasks.sessionId, sessionIds))
+        .orderBy(pomodoroTasks.orderIndex);
+      tasksBySession = allTasks.reduce((acc, t) => {
+        (acc[t.sessionId] ||= []).push(t);
+        return acc;
+      }, {} as Record<string, TaskType[]>);
+    }
+    const sessionsWithTasks = sessions.map((session) => ({
+      ...session,
+      tasks: tasksBySession[session.id] ?? [],
+    }));
     
     // Return paginated response
     return c.json({
@@ -234,7 +242,7 @@ app.post('/sessions', zValidator('json', createSessionSchema, springBootValidato
       startTime: null,
       workDuration: data.workDuration,
       breakDuration: data.breakDuration,
-      status: 'ACTIVE' as const,
+      status: 'PAUSED' as const,
       sessionType: data.sessionType || 'WORK',
       completedCycles: 0,
       createdAt: now,
@@ -603,8 +611,10 @@ app.put('/config', zValidator('json', configSchema, springBootValidator), async 
         cyclesBeforeLongBreak: data.cyclesBeforeLongBreak ?? 4,
         alarmSound: data.alarmSound ?? 'default',
         alarmVolume: data.alarmVolume ?? 50,
+        soundEnabled: data.soundEnabled ?? true,
         autoStartBreaks: data.autoStartBreaks ?? true,
         autoStartWork: data.autoStartWork ?? false,
+        carryOverIncompleteTasks: data.carryOverIncompleteTasks ?? true,
         createdAt: now,
         updatedAt: now,
       };

--- a/apps/backend/src/routes/pomodoro.ts
+++ b/apps/backend/src/routes/pomodoro.ts
@@ -42,8 +42,10 @@ const configSchema = z.object({
   cyclesBeforeLongBreak: z.number().min(1).optional(),
   alarmSound: z.string().optional(),
   alarmVolume: z.number().min(0).max(100).optional(),
+  soundEnabled: z.boolean().optional(),
   autoStartBreaks: z.boolean().optional(),
   autoStartWork: z.boolean().optional(),
+  carryOverIncompleteTasks: z.boolean().optional(),
 });
 
 const updateTaskSchema = z.object({
@@ -93,9 +95,20 @@ app.get('/sessions', async (c) => {
       .limit(size)
       .offset(offset);
     
+    // Get tasks for each session
+    const sessionsWithTasks = await Promise.all(
+      sessions.map(async (session) => {
+        const tasks = await db.select()
+          .from(pomodoroTasks)
+          .where(eq(pomodoroTasks.sessionId, session.id))
+          .orderBy(pomodoroTasks.orderIndex);
+        return { ...session, tasks };
+      })
+    );
+    
     // Return paginated response
     return c.json({
-      content: sessions,
+      content: sessionsWithTasks,
       totalElements,
       totalPages,
       size,
@@ -468,6 +481,55 @@ app.put('/sessions/:sessionId/tasks/:taskId', zValidator('json', updateTaskSchem
   }
 });
 
+// DELETE /pomodoro/sessions/:sessionId/tasks/:taskId
+app.delete('/sessions/:sessionId/tasks/:taskId', async (c) => {
+  const db = c.get('db');
+  const userId = c.get('userId');
+  const sessionId = c.req.param('sessionId');
+  const taskId = c.req.param('taskId');
+  
+  try {
+    // Verify session belongs to user
+    const session = await db.select()
+      .from(pomodoroSessions)
+      .where(and(
+        eq(pomodoroSessions.id, sessionId),
+        eq(pomodoroSessions.userId, userId as string)
+      ))
+      .get();
+    
+    if (!session) {
+      return c.json(
+        createLocalizedError('NOT_FOUND', c, { detail: 'Session not found' }),
+        404 as ContentfulStatusCode
+      );
+    }
+    
+    // Delete the task
+    const result = await db.delete(pomodoroTasks)
+      .where(and(
+        eq(pomodoroTasks.id, taskId),
+        eq(pomodoroTasks.sessionId, sessionId)
+      ))
+      .returning();
+    
+    if (!result.length) {
+      return c.json(
+        createLocalizedError('NOT_FOUND', c, { detail: 'Task not found' }),
+        404 as ContentfulStatusCode
+      );
+    }
+    
+    return c.json({ message: 'Task deleted successfully' });
+  } catch (error) {
+    console.error('Delete task error:', error);
+    return c.json(
+      createLocalizedError('INTERNAL_ERROR', c),
+      500 as ContentfulStatusCode
+    );
+  }
+});
+
 // GET /pomodoro/config
 app.get('/config', async (c) => {
   const db = c.get('db');
@@ -488,8 +550,10 @@ app.get('/config', async (c) => {
         cyclesBeforeLongBreak: 4,
         alarmSound: 'default',
         alarmVolume: 50,
+        soundEnabled: true,
         autoStartBreaks: true,
         autoStartWork: false,
+        carryOverIncompleteTasks: true,
       });
     }
     

--- a/apps/frontend/src/components/pomodoro/PomodoroConfig.tsx
+++ b/apps/frontend/src/components/pomodoro/PomodoroConfig.tsx
@@ -212,6 +212,19 @@ export function PomodoroConfig() {
               />
               <span className="text-sm">サウンド通知を有効化</span>
             </label>
+
+            <label className="flex items-center gap-3">
+              <input
+                type="checkbox"
+                checked={formData.carryOverIncompleteTasks ?? true}
+                onChange={(e) => setFormData({
+                  ...formData,
+                  carryOverIncompleteTasks: e.target.checked
+                })}
+                className="w-4 h-4 rounded text-blue-600 focus:ring-blue-500"
+              />
+              <span className="text-sm">未完了タスクを次のセッションに引き継ぐ</span>
+            </label>
           </div>
 
           {formData.soundEnabled && (
@@ -223,19 +236,19 @@ export function PomodoroConfig() {
                 type="range"
                 min="0"
                 max="100"
-                value={Math.round((formData.soundVolume ?? 0.5) * 100)}
+                value={formData.alarmVolume ?? 50}
                 onChange={(e) => {
                   const raw = Number(e.target.value);
                   const clamped = Number.isFinite(raw) ? Math.min(100, Math.max(0, raw)) : 50;
                   setFormData({
                     ...formData,
-                    soundVolume: clamped / 100,
+                    alarmVolume: clamped,
                   });
                 }}
                 className="w-full"
               />
               <div className="text-xs text-muted-foreground text-center">
-                {Math.round((formData.soundVolume ?? 0.5) * 100)}%
+                {formData.alarmVolume ?? 50}%
               </div>
             </div>
           )}

--- a/apps/frontend/src/components/pomodoro/PomodoroTimer.tsx
+++ b/apps/frontend/src/components/pomodoro/PomodoroTimer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { PomodoroSession, SessionStatus, SessionType, SessionAction } from '@/types/pomodoro';
 import { pomodoroApi } from '@/lib/pomodoro-api';
+import { usePomodoroConfig } from '@/hooks/usePomodoro';
 import { Button } from '@/components/ui';
 import { Play, Pause, RotateCcw, Coffee, Brain } from 'lucide-react';
 import { cn } from '@/lib/cn';
@@ -9,24 +10,28 @@ interface PomodoroTimerProps {
   session: PomodoroSession;
   onComplete?: () => void;
   onUpdate?: (session: PomodoroSession) => void;
+  onStartNewSession?: () => void;
 }
 
-export function PomodoroTimer({ session, onComplete, onUpdate }: PomodoroTimerProps) {
+export function PomodoroTimer({ session, onComplete, onUpdate, onStartNewSession }: PomodoroTimerProps) {
   const [timeLeft, setTimeLeft] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const { data: config } = usePomodoroConfig();
 
   useEffect(() => {
-    // Initialize audio - silently fail if sound file doesn't exist
-    try {
-      audioRef.current = new Audio('/sounds/alarm.mp3');
-      audioRef.current.volume = 0.5;
-      // Preload the audio to check if it exists
-      audioRef.current.load();
-    } catch {
-      console.warn('Audio file not found, alarm will be silent');
-      audioRef.current = null;
+    // Initialize audio if sound is enabled
+    if (config?.soundEnabled) {
+      try {
+        audioRef.current = new Audio('/sounds/alarm.mp3');
+        audioRef.current.volume = (config.alarmVolume ?? 50) / 100;
+        // Preload the audio to check if it exists
+        audioRef.current.load();
+      } catch {
+        console.warn('Audio file not found, alarm will be silent');
+        audioRef.current = null;
+      }
     }
     
     return () => {
@@ -34,7 +39,7 @@ export function PomodoroTimer({ session, onComplete, onUpdate }: PomodoroTimerPr
         clearInterval(intervalRef.current);
       }
     };
-  }, []);
+  }, [config]);
 
   useEffect(() => {
     if (session) {
@@ -103,6 +108,12 @@ export function PomodoroTimer({ session, onComplete, onUpdate }: PomodoroTimerPr
   };
 
   const handleStart = async () => {
+    // If this is a temporary/pending session, create a new real session
+    if (session.status === SessionStatus.PENDING || session.id.startsWith('temp-')) {
+      onStartNewSession?.();
+      return;
+    }
+    
     try {
       const updatedSession = await pomodoroApi.updateSession(session.id, {
         action: SessionAction.START
@@ -232,18 +243,21 @@ export function PomodoroTimer({ session, onComplete, onUpdate }: PomodoroTimerPr
               size="lg"
               variant="primary"
               className="gap-2"
+              data-testid="start-button"
             >
               <Play className="w-5 h-5" />
               開始
             </Button>
-            <Button
-              onClick={handleComplete}
-              size="lg"
-              variant="secondary"
-              className="gap-2"
-            >
-              スキップ
-            </Button>
+            {session.status !== SessionStatus.PENDING && (
+              <Button
+                onClick={handleComplete}
+                size="lg"
+                variant="secondary"
+                className="gap-2"
+              >
+                スキップ
+              </Button>
+            )}
           </>
         ) : (
           <>

--- a/apps/frontend/src/components/pomodoro/PomodoroTimer.tsx
+++ b/apps/frontend/src/components/pomodoro/PomodoroTimer.tsx
@@ -23,6 +23,12 @@ export function PomodoroTimer({ session, onComplete, onUpdate, onStartNewSession
   useEffect(() => {
     // Initialize audio if sound is enabled
     if (config?.soundEnabled) {
+      // Stop previous audio instance if any
+      try {
+        audioRef.current?.pause?.();
+      } catch {
+        // Ignore errors when pausing previous audio
+      }
       try {
         audioRef.current = new Audio('/sounds/alarm.mp3');
         audioRef.current.volume = (config.alarmVolume ?? 50) / 100;
@@ -32,6 +38,14 @@ export function PomodoroTimer({ session, onComplete, onUpdate, onStartNewSession
         console.warn('Audio file not found, alarm will be silent');
         audioRef.current = null;
       }
+    } else {
+      // Sound disabled
+      try {
+        audioRef.current?.pause?.();
+      } catch {
+        // Ignore errors when pausing audio
+      }
+      audioRef.current = null;
     }
     
     return () => {
@@ -143,7 +157,9 @@ export function PomodoroTimer({ session, onComplete, onUpdate, onStartNewSession
         action: SessionAction.CANCEL
       });
       setIsRunning(false);
-      setTimeLeft(session.workDuration * 60);
+      const resetDuration =
+        session.sessionType === SessionType.WORK ? session.workDuration : session.breakDuration;
+      setTimeLeft(resetDuration * 60);
       onUpdate?.(updatedSession);
     } catch (error) {
       console.error('Failed to reset session:', error);

--- a/apps/frontend/src/hooks/usePomodoro.ts
+++ b/apps/frontend/src/hooks/usePomodoro.ts
@@ -13,7 +13,7 @@ export function useActiveSession() {
     refetchInterval: (query) => {
       // Only poll if there's an active session that's running
       const session = query.state.data;
-      if (session && session.status === 'ACTIVE') {
+      if (session && session.status === 'ACTIVE' && session.startTime) {
         return 1000; // Poll every second for active sessions
       }
       return false; // Don't poll for paused, completed, or no session

--- a/apps/frontend/src/hooks/usePomodoro.ts
+++ b/apps/frontend/src/hooks/usePomodoro.ts
@@ -10,7 +10,14 @@ export function useActiveSession() {
   return useQuery({
     queryKey: ['pomodoro-session-active'],
     queryFn: () => pomodoroApi.getActiveSession(),
-    refetchInterval: 1000, // Refetch every second to update timer
+    refetchInterval: (query) => {
+      // Only poll if there's an active session that's running
+      const session = query.state.data;
+      if (session && session.status === 'ACTIVE') {
+        return 1000; // Poll every second for active sessions
+      }
+      return false; // Don't poll for paused, completed, or no session
+    },
     retry: false, // Don't retry 404 errors
     gcTime: 0 // Don't cache null results
   });

--- a/apps/frontend/src/pages/Pomodoro.tsx
+++ b/apps/frontend/src/pages/Pomodoro.tsx
@@ -84,7 +84,7 @@ export function Pomodoro() {
         const breakSessionData = prepareSessionData(
           config,
           undefined,        // no initial task
-          tasks,
+          session.tasks,
           breakType
         );
 
@@ -104,7 +104,7 @@ export function Pomodoro() {
         const workSessionData = prepareSessionData(
           config,
           undefined,         // no initial task
-          tasks,
+          session.tasks,
           SessionType.WORK
         );
 

--- a/apps/frontend/src/pages/Pomodoro.tsx
+++ b/apps/frontend/src/pages/Pomodoro.tsx
@@ -14,7 +14,7 @@ import {
   useUpdateSession,
 } from '@/hooks/usePomodoro';
 import { PomodoroSession, SessionAction, SessionStatus, SessionType } from '@/types/pomodoro';
-import { prepareSessionData, getIncompleteTasks } from '@/utils/pomodoroHelpers';
+import { prepareSessionData } from '@/utils/pomodoroHelpers';
 import { Card } from '@/components/ui/Card';
 import { Clock } from 'lucide-react';
 
@@ -31,7 +31,7 @@ export function Pomodoro() {
   const tempSession = useMemo<PomodoroSession | null>(() => {
     if (!config || activeSession) return null;
     return {
-      id: `temp-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      id: `temp-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
       userId: '',
       workDuration: config.workDuration,
       breakDuration: config.shortBreakDuration,
@@ -77,17 +77,16 @@ export function Pomodoro() {
       // Determine break type based on completed cycles
       // The session has been marked as completed by PomodoroTimer, so cycles are already updated
       const isLongBreak = session.completedCycles % config.cyclesBeforeLongBreak === 0;
-      const breakDuration = isLongBreak ? config.longBreakDuration : config.shortBreakDuration;
       const breakType = isLongBreak ? SessionType.LONG_BREAK : SessionType.SHORT_BREAK;
 
       // Create and auto-start break session after a short delay
       setTimeout(() => {
-        const breakSessionData = {
-          workDuration: config.workDuration,
-          breakDuration: breakDuration,
-          sessionType: breakType,
-          tasks: getIncompleteTasks(tasks),
-        };
+        const breakSessionData = prepareSessionData(
+          config,
+          undefined,        // no initial task
+          tasks,
+          breakType
+        );
 
         createSession.mutate(breakSessionData, {
           onSuccess: (newSession) => {
@@ -102,12 +101,12 @@ export function Pomodoro() {
     } else if (session.sessionType !== 'WORK' && config.autoStartWork) {
       // Auto-start work session after break
       setTimeout(() => {
-        const workSessionData = {
-          workDuration: config.workDuration,
-          breakDuration: config.shortBreakDuration,
-          sessionType: SessionType.WORK,
-          tasks: getIncompleteTasks(tasks),
-        };
+        const workSessionData = prepareSessionData(
+          config,
+          undefined,         // no initial task
+          tasks,
+          SessionType.WORK
+        );
 
         createSession.mutate(workSessionData, {
           onSuccess: (newSession) => {
@@ -134,7 +133,7 @@ export function Pomodoro() {
     const state = location.state as { autoStart?: boolean } | null;
     if (state?.autoStart && !activeSession && config && !autoStartHandled.current) {
       autoStartHandled.current = true;
-      handleCreateSession();
+      handleCreateSession(undefined, SessionType.WORK, true);
       // Clear the state to prevent re-starting on refresh
       navigate(
         { pathname: location.pathname, search: location.search, hash: location.hash },

--- a/apps/frontend/src/pages/Pomodoro.tsx
+++ b/apps/frontend/src/pages/Pomodoro.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { AppLayout } from '@/components/layout';
 import {
@@ -15,7 +15,6 @@ import {
 } from '@/hooks/usePomodoro';
 import { PomodoroSession, SessionAction, SessionStatus, SessionType } from '@/types/pomodoro';
 import { prepareSessionData, getIncompleteTasks } from '@/utils/pomodoroHelpers';
-import { Button } from '@/components/ui';
 import { Card } from '@/components/ui/Card';
 import { Clock } from 'lucide-react';
 
@@ -28,15 +27,45 @@ export function Pomodoro() {
   const createSession = useCreateSession();
   const updateSession = useUpdateSession();
 
+  // Create a temporary session object for display when no active session exists
+  const tempSession = useMemo<PomodoroSession | null>(() => {
+    if (!config || activeSession) return null;
+    return {
+      id: `temp-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      userId: '',
+      workDuration: config.workDuration,
+      breakDuration: config.shortBreakDuration,
+      sessionType: SessionType.WORK,
+      status: SessionStatus.PENDING,
+      completedCycles: 0,
+      tasks: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+  }, [config, activeSession]);
+
+  // Use active session or temporary session for display
+  const displaySession = activeSession || tempSession;
+
   // Tasks from active session
   const tasks = activeSession?.tasks || [];
 
-  const handleCreateSession = (initialTask?: string, sessionType: SessionType = SessionType.WORK) => {
+  const handleCreateSession = (initialTask?: string, sessionType: SessionType = SessionType.WORK, autoStart: boolean = false) => {
     if (!config) return;
 
     const sessionData = prepareSessionData(config, initialTask, tasks, sessionType);
 
-    createSession.mutate(sessionData);
+    createSession.mutate(sessionData, {
+      onSuccess: (newSession) => {
+        if (autoStart) {
+          // Auto-start the session immediately
+          updateSession.mutate({
+            id: newSession.id,
+            action: SessionAction.START,
+          });
+        }
+      }
+    });
   };
 
   const handleSessionComplete = (completedSession?: PomodoroSession) => {
@@ -143,26 +172,17 @@ export function Pomodoro() {
           {/* Timer section */}
           <Card className="relative p-6">
             <PomodoroConfig />
-            {activeSession ? (
+            {displaySession ? (
               <PomodoroTimer
-                session={activeSession}
+                session={displaySession}
                 onComplete={() => {}}
                 onUpdate={handleSessionUpdate}
+                onStartNewSession={() => handleCreateSession(undefined, SessionType.WORK, true)}
               />
             ) : (
               <div className="text-center py-12">
                 <Clock className="h-16 w-16 mx-auto mb-4 text-muted-foreground" />
-                <h2 className="text-xl font-semibold mb-2">アクティブなセッションがありません</h2>
-                <p className="text-muted-foreground mb-6">
-                  新しいセッションを開始して集中を始めましょう
-                </p>
-                <Button
-                  onClick={() => handleCreateSession()}
-                  size="lg"
-                  disabled={createSession.isPending}
-                >
-                  {createSession.isPending ? '作成中...' : 'セッションを開始'}
-                </Button>
+                <h2 className="text-xl font-semibold mb-2">読み込み中...</h2>
               </div>
             )}
           </Card>

--- a/apps/frontend/src/types/pomodoro.ts
+++ b/apps/frontend/src/types/pomodoro.ts
@@ -14,6 +14,7 @@ export interface PomodoroSession {
 }
 
 export enum SessionStatus {
+  PENDING = 'PENDING',
   ACTIVE = 'ACTIVE',
   PAUSED = 'PAUSED',
   COMPLETED = 'COMPLETED',
@@ -45,8 +46,9 @@ export interface PomodoroConfig {
   autoStartBreaks: boolean;
   autoStartWork: boolean;
   soundEnabled: boolean;
-  soundVolume: number;
+  alarmVolume: number;
   alarmSound: string;
+  carryOverIncompleteTasks?: boolean;
 }
 
 export interface CreatePomodoroSessionRequest {
@@ -88,6 +90,8 @@ export interface UpdatePomodoroConfigRequest {
   alarmVolume?: number;
   autoStartBreaks?: boolean;
   autoStartWork?: boolean;
+  soundEnabled?: boolean;
+  carryOverIncompleteTasks?: boolean;
 }
 
 export interface PaginatedResponse<T> {

--- a/apps/frontend/src/types/pomodoro.ts
+++ b/apps/frontend/src/types/pomodoro.ts
@@ -48,7 +48,7 @@ export interface PomodoroConfig {
   soundEnabled: boolean;
   alarmVolume: number;
   alarmSound: string;
-  carryOverIncompleteTasks?: boolean;
+  carryOverIncompleteTasks: boolean;
 }
 
 export interface CreatePomodoroSessionRequest {

--- a/apps/frontend/src/utils/pomodoroHelpers.ts
+++ b/apps/frontend/src/utils/pomodoroHelpers.ts
@@ -13,8 +13,8 @@ export function prepareSessionData(
     tasks.push({ description: initialTask });
   }
   
-  // Add incomplete tasks from current session
-  if (currentTasks) {
+  // Add incomplete tasks from current session if carryOverIncompleteTasks is enabled
+  if (currentTasks && (config.carryOverIncompleteTasks ?? true)) {
     const incompleteTasks = getIncompleteTasks(currentTasks);
     tasks.push(...incompleteTasks);
   }


### PR DESCRIPTION
## Summary
- Fixed initial Pomodoro state to show timer ready instead of "no active session" message
- Optimized network requests by implementing smart polling (only polls when session is active)
- Enhanced Pomodoro history with complete task details display
- Added configurable incomplete task carry-over setting
- Fixed critical missing DELETE endpoint for Pomodoro tasks
- Resolved field name inconsistencies (soundVolume vs alarmVolume)
- Added soundEnabled configuration option

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass 
- [x] Build process completes successfully
- [x] Unit tests pass (270/270)
- [ ] Manual testing of Pomodoro features
- [ ] Verify timer display on initial load
- [ ] Confirm network requests are optimized (no 404 polling)
- [ ] Test task deletion functionality
- [ ] Verify sound settings work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Carry-over incomplete tasks option (default: enabled).
  * Sound enable/disable setting (default: enabled).
  * Sessions now include embedded tasks; you can delete a task from a specific session.
  * Timer can start a new session when none is active; PENDING session state added.

* **Improvements**
  * Alarm volume uses 0–100% and timer audio respects sound settings.
  * Reduced polling when there’s no active session.

* **Tests**
  * Tests updated to expect embedded tasks and PAUSED default on new sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->