### PR TITLE
fix: Resolve Pomodoro config 500 error

### DIFF
--- a/apps/frontend/src/components/pomodoro/PomodoroConfig.tsx
+++ b/apps/frontend/src/components/pomodoro/PomodoroConfig.tsx
@@ -44,7 +44,32 @@ export function PomodoroConfig() {
   };
 
   const handleSave = () => {
-    updateMutation.mutate(formData);
+    // Only send fields that are part of UpdatePomodoroConfigRequest
+    const { 
+      workDuration, 
+      shortBreakDuration, 
+      longBreakDuration, 
+      cyclesBeforeLongBreak,
+      alarmSound,
+      alarmVolume,
+      autoStartBreaks,
+      autoStartWork,
+      soundEnabled,
+      carryOverIncompleteTasks
+    } = formData;
+    
+    updateMutation.mutate({
+      workDuration,
+      shortBreakDuration,
+      longBreakDuration,
+      cyclesBeforeLongBreak,
+      alarmSound,
+      alarmVolume,
+      autoStartBreaks,
+      autoStartWork,
+      soundEnabled,
+      carryOverIncompleteTasks
+    });
   };
 
   if (!isOpen) {

--- a/apps/frontend/src/components/pomodoro/PomodoroConfig.tsx
+++ b/apps/frontend/src/components/pomodoro/PomodoroConfig.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { pomodoroApi } from '@/lib/pomodoro-api';
-import { PomodoroConfig as PomodoroConfigType } from '@/types/pomodoro';
+import { PomodoroConfig as PomodoroConfigType, UpdatePomodoroConfigRequest } from '@/types/pomodoro';
 import { Settings, X, Save } from 'lucide-react';
 import { Button } from '@/components/ui';
 import { cn } from '@/lib/cn';
@@ -20,7 +20,7 @@ export function PomodoroConfig() {
   const [formData, setFormData] = useState<Partial<PomodoroConfigType>>({});
 
   const updateMutation = useMutation({
-    mutationFn: (data: Partial<PomodoroConfigType>) => pomodoroApi.updateConfig(data),
+    mutationFn: (data: UpdatePomodoroConfigRequest) => pomodoroApi.updateConfig(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['pomodoro-config'] });
       toast.success('設定が保存されました');
@@ -44,32 +44,21 @@ export function PomodoroConfig() {
   };
 
   const handleSave = () => {
-    // Only send fields that are part of UpdatePomodoroConfigRequest
-    const { 
-      workDuration, 
-      shortBreakDuration, 
-      longBreakDuration, 
-      cyclesBeforeLongBreak,
-      alarmSound,
-      alarmVolume,
-      autoStartBreaks,
-      autoStartWork,
-      soundEnabled,
-      carryOverIncompleteTasks
-    } = formData;
+    // Build a typed payload that matches UpdatePomodoroConfigRequest
+    const payload: UpdatePomodoroConfigRequest = {
+      workDuration: formData.workDuration,
+      shortBreakDuration: formData.shortBreakDuration,
+      longBreakDuration: formData.longBreakDuration,
+      cyclesBeforeLongBreak: formData.cyclesBeforeLongBreak,
+      alarmSound: formData.alarmSound,
+      alarmVolume: formData.alarmVolume,
+      autoStartBreaks: formData.autoStartBreaks,
+      autoStartWork: formData.autoStartWork,
+      soundEnabled: formData.soundEnabled,
+      carryOverIncompleteTasks: formData.carryOverIncompleteTasks
+    };
     
-    updateMutation.mutate({
-      workDuration,
-      shortBreakDuration,
-      longBreakDuration,
-      cyclesBeforeLongBreak,
-      alarmSound,
-      alarmVolume,
-      autoStartBreaks,
-      autoStartWork,
-      soundEnabled,
-      carryOverIncompleteTasks
-    });
+    updateMutation.mutate(payload);
   };
 
   if (!isOpen) {

--- a/apps/frontend/src/types/pomodoro.ts
+++ b/apps/frontend/src/types/pomodoro.ts
@@ -39,6 +39,8 @@ export interface PomodoroTask {
 }
 
 export interface PomodoroConfig {
+  id?: string;
+  userId?: string;
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
@@ -49,6 +51,8 @@ export interface PomodoroConfig {
   alarmVolume: number;
   alarmSound: string;
   carryOverIncompleteTasks: boolean;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface CreatePomodoroSessionRequest {

--- a/apps/frontend/src/types/pomodoro.ts
+++ b/apps/frontend/src/types/pomodoro.ts
@@ -39,8 +39,8 @@ export interface PomodoroTask {
 }
 
 export interface PomodoroConfig {
-  id?: string;
-  userId?: string;
+  readonly id?: string;
+  readonly userId?: string;
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
@@ -51,8 +51,8 @@ export interface PomodoroConfig {
   alarmVolume: number;
   alarmSound: string;
   carryOverIncompleteTasks: boolean;
-  createdAt?: string;
-  updatedAt?: string;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
 }
 
 export interface CreatePomodoroSessionRequest {


### PR DESCRIPTION
## Summary
- Fix PUT /api/v1/pomodoro/config returning 500 error
- Ensure only valid UpdatePomodoroConfigRequest fields are sent in request body
- Add optional server-generated fields to PomodoroConfig interface for proper type alignment

## Problem
The Pomodoro settings save was failing with a 500 error because the frontend was sending the entire config object including server-generated fields (id, userId, createdAt, updatedAt) which the backend UpdatePomodoroConfigRequest schema doesn't expect.

## Solution
- Extract and send only updatable fields in handleSave to match backend API contract
- Add optional fields to PomodoroConfig interface to properly type the server response
- Properly handle soundEnabled and carryOverIncompleteTasks fields

## Test Results
✅ TypeScript compilation passes
✅ Linting passes  
✅ Build succeeds
✅ Unit tests pass (270/270)
✅ Backend API changes are properly typed

Note: Some E2E tests fail due to pre-existing localization issues unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving Pomodoro settings by sending a minimal, well-typed payload to the backend, reducing potential save errors. No UI or workflow changes.

* **Chores**
  * Extended internal configuration with optional identifiers and timestamps to support tracking and auditing. No impact on user behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->