### PR TITLE
fix: Use correct D1 database binding name in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: apps/backend
-          command: d1 migrations apply personal-hub-prod --env production --remote
+          command: d1 migrations apply DB --env production --remote
       - name: Verify migrations applied
         run: |
           echo "Migrations applied successfully"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,9 +13,9 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:all": "npm test && npm run test:integration",
     "clean": "rm -rf dist .wrangler node_modules",
-    "db:migrate:local": "wrangler d1 migrations apply personal-hub-local --local",
-    "db:migrate:dev": "wrangler d1 migrations apply personal-hub --env development --remote",
-    "db:migrate:prod": "wrangler d1 migrations apply personal-hub-prod --env production --remote"
+    "db:migrate:local": "wrangler d1 migrations apply DB --local",
+    "db:migrate:dev": "wrangler d1 migrations apply DB --env development --remote",
+    "db:migrate:prod": "wrangler d1 migrations apply DB --env production --remote"
   },
   "dependencies": {
     "@hono/zod-validator": "^0.7.2",


### PR DESCRIPTION
## Summary
Fixed deployment pipeline failure by using the correct D1 database binding name in migration commands.

## Problem
The deployment workflow was failing with the error:
```
Error: The process '/opt/hostedtoolcache/node/20.19.4/x64/bin/npx' failed with exit code 1
```

When running:
```bash
wrangler d1 migrations apply personal-hub-prod --env production --remote
```

## Root Cause
The migration command was using the database name (`personal-hub-prod`) instead of the binding name (`DB`). According to wrangler.toml, all environments use `DB` as the binding name for the D1 database.

## Solution
- Changed `d1 migrations apply personal-hub-prod` to `d1 migrations apply DB`
- Updated all npm migration scripts to use the correct binding name
- This ensures the migrations command references the correct database binding

## Testing
- Verified locally that `wrangler d1 migrations list DB --local` works correctly
- The binding name matches the configuration in wrangler.toml

## Files Changed
- `.github/workflows/deploy.yml` - Fixed migration command to use DB binding
- `apps/backend/package.json` - Updated migration scripts to use DB binding

This fix will allow the deployment pipeline to successfully apply database migrations.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized database migration configuration across local, development, and production to use a unified database identifier, improving consistency and reducing configuration drift.
  - Updated deployment pipeline to align with the new migration target, streamlining operations and reducing risk of misconfiguration.
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->