### PR TITLE
fix: Fix empty migration file causing deployment failure

### DIFF
--- a/apps/backend/migrations/0004_add_pending_status.sql
+++ b/apps/backend/migrations/0004_add_pending_status.sql
@@ -1,6 +1,16 @@
 -- Add PENDING status to pomodoro_sessions
 -- SQLite doesn't support ALTER COLUMN, so we need to recreate the table with updated CHECK constraint
 
+-- IMPORTANT: Before running in production, verify no invalid statuses exist:
+-- SELECT status, COUNT(*) FROM pomodoro_sessions
+-- WHERE status NOT IN ('ACTIVE','PAUSED','COMPLETED','CANCELLED','PENDING')
+-- GROUP BY status;
+-- Expected result: no rows
+
+-- Disable foreign key checks and start transaction for atomic operation
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+
 -- Step 1: Create a new table with the updated CHECK constraint including PENDING
 CREATE TABLE pomodoro_sessions_new (
   id TEXT PRIMARY KEY,
@@ -14,7 +24,7 @@ CREATE TABLE pomodoro_sessions_new (
   session_type TEXT,
   created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
   updated_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE no action ON DELETE no action
+  FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE NO ACTION ON DELETE NO ACTION
 );
 
 -- Step 2: Copy existing data from the old table to the new table
@@ -30,3 +40,16 @@ ALTER TABLE pomodoro_sessions_new RENAME TO pomodoro_sessions;
 
 -- Step 5: Recreate the index
 CREATE INDEX idx_pomodoro_sessions_user_id ON pomodoro_sessions(user_id);
+
+-- Step 6: Add trigger to auto-update updated_at column
+CREATE TRIGGER pomodoro_sessions_updated_at
+AFTER UPDATE ON pomodoro_sessions
+BEGIN
+  UPDATE pomodoro_sessions
+  SET updated_at = CURRENT_TIMESTAMP
+  WHERE rowid = NEW.rowid;
+END;
+
+-- Commit transaction and re-enable foreign key checks
+COMMIT;
+PRAGMA foreign_keys=ON;

--- a/apps/backend/migrations/0004_add_pending_status.sql
+++ b/apps/backend/migrations/0004_add_pending_status.sql
@@ -1,4 +1,32 @@
 -- Add PENDING status to pomodoro_sessions
--- SQLite doesn't support ALTER COLUMN, so we need to recreate the table or use a workaround
--- Since this is a CHECK constraint issue, we'll just document that PENDING is now a valid value
--- The application code will handle this new status value
+-- SQLite doesn't support ALTER COLUMN, so we need to recreate the table with updated CHECK constraint
+
+-- Step 1: Create a new table with the updated CHECK constraint including PENDING
+CREATE TABLE pomodoro_sessions_new (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  start_time TEXT,
+  end_time TEXT,
+  work_duration INTEGER NOT NULL,
+  break_duration INTEGER NOT NULL,
+  completed_cycles INTEGER DEFAULT 0 NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('ACTIVE', 'PAUSED', 'COMPLETED', 'CANCELLED', 'PENDING')),
+  session_type TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE no action ON DELETE no action
+);
+
+-- Step 2: Copy existing data from the old table to the new table
+INSERT INTO pomodoro_sessions_new (id, user_id, start_time, end_time, work_duration, break_duration, completed_cycles, status, session_type, created_at, updated_at)
+SELECT id, user_id, start_time, end_time, work_duration, break_duration, completed_cycles, status, session_type, created_at, updated_at
+FROM pomodoro_sessions;
+
+-- Step 3: Drop the old table
+DROP TABLE pomodoro_sessions;
+
+-- Step 4: Rename the new table to the original name
+ALTER TABLE pomodoro_sessions_new RENAME TO pomodoro_sessions;
+
+-- Step 5: Recreate the index
+CREATE INDEX idx_pomodoro_sessions_user_id ON pomodoro_sessions(user_id);


### PR DESCRIPTION
## Summary
- Fixed empty migration file `0004_add_pending_status.sql` that was causing CI deployment failures
- Added proper SQL statements to add PENDING status to pomodoro_sessions table
- Used table recreation approach since SQLite doesn't support direct CHECK constraint modification

## Problem
The migration file contained only comments without actual SQL statements, causing `wrangler d1 migrations apply` to fail in the deployment workflow.

## Solution
Implemented the migration by:
1. Creating a new table with updated CHECK constraint including PENDING status
2. Copying existing data from old table
3. Dropping old table and renaming new table
4. Recreating necessary indexes

## Test plan
- [x] Backend tests pass locally
- [x] Linting passes
- [x] Type checking passes
- [x] Build succeeds
- [ ] CI deployment workflow should complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Pending” status for pomodoro sessions to improve state tracking before a session starts.
  * Sessions now auto-update their modified timestamp when changed.

* **Chores**
  * Performed a safe, atomic database migration to support the new status while preserving existing data and indexes.
  * Ensured backward compatibility with existing sessions and user data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->