### PR TITLE
fix: restore mobile hamburger menu

### DIFF
--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFeatures } from '@/contexts/FeatureContext';
 import { useCommandPalette } from '@/contexts/CommandPaletteContext';
@@ -33,12 +33,15 @@ export function Sidebar({ isOpen = false, onClose }: SidebarProps) {
   const { t } = useTranslation('common');
   const { features: featurePreferences } = useFeatures();
   const { openCommandPalette } = useCommandPalette();
+  const previousPathRef = useRef(location.pathname);
 
   // Close sidebar on route change (mobile)
   useEffect(() => {
-    if (isOpen && onClose) {
+    if (previousPathRef.current !== location.pathname && isOpen && onClose) {
       onClose();
     }
+
+    previousPathRef.current = location.pathname;
   }, [location.pathname, isOpen, onClose]);
 
   const allNavItems: (NavItem & { featureKey?: keyof typeof featurePreferences })[] = [


### PR DESCRIPTION
## Summary
- keep a ref of the previous path so the sidebar only closes after navigation
- prevent the mobile hamburger menu from immediately closing after toggle

## Testing
- pnpm lint
- pnpm build
- pnpm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar now closes only when navigating to a different page, preventing unintended closures on route events that don’t change the path (e.g., in-page updates or repeated triggers). This improves stability and reduces disruption during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->