### PR TITLE
feat: refresh mobile language selector

### DIFF
--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCommandPalette } from '@/contexts/CommandPaletteContext';
 import { Menu, User, LogOut, Settings, ChevronDown, Sun, Moon, Globe, Terminal, X } from 'lucide-react';
+import { createPortal } from 'react-dom';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -17,10 +18,183 @@ export function Header({ onMenuClick }: HeaderProps) {
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const [isLanguageModalOpen, setIsLanguageModalOpen] = useState(false);
   const { t, i18n } = useTranslation('common');
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null);
   
   const changeLanguage = (lng: string) => {
     i18n.changeLanguage(lng);
   };
+
+  useEffect(() => {
+    if (!isLanguageModalOpen) {
+      return;
+    }
+
+    const activeElement = document.activeElement;
+    previouslyFocusedElementRef.current = activeElement instanceof HTMLElement ? activeElement : null;
+
+    const rootElement = document.getElementById('root') as (HTMLElement & { inert?: boolean }) | null;
+    if (rootElement) {
+      rootElement.dataset.languageModalHidden = 'true';
+      rootElement.setAttribute('aria-hidden', 'true');
+      const elementWithInert = rootElement as HTMLElement & { inert?: boolean };
+      if (typeof elementWithInert.inert === 'boolean') {
+        elementWithInert.inert = true;
+      } else {
+        rootElement.setAttribute('inert', '');
+      }
+    }
+
+    const getFocusableElements = () => {
+      const modal = modalRef.current;
+      if (!modal) {
+        return [] as HTMLElement[];
+      }
+      const focusableSelectors = [
+        'a[href]',
+        'button:not([disabled])',
+        'textarea:not([disabled])',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])'
+      ].join(',');
+      return Array.from(modal.querySelectorAll<HTMLElement>(focusableSelectors)).filter(
+        (element) => !element.hasAttribute('aria-hidden')
+      );
+    };
+
+    const focusableElements = getFocusableElements();
+    const firstFocusable = focusableElements[0];
+
+    if (firstFocusable) {
+      firstFocusable.focus();
+    } else {
+      modalRef.current?.focus();
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setIsLanguageModalOpen(false);
+        return;
+      }
+
+      if (event.key === 'Tab') {
+        const currentFocusable = getFocusableElements();
+        if (!currentFocusable.length) {
+          event.preventDefault();
+          modalRef.current?.focus();
+          return;
+        }
+
+        const first = currentFocusable[0];
+        const last = currentFocusable[currentFocusable.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === first || document.activeElement === modalRef.current) {
+            event.preventDefault();
+            (last ?? first).focus();
+          }
+        } else if (document.activeElement === last) {
+          event.preventDefault();
+          (first ?? last).focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+
+      if (rootElement && rootElement.dataset.languageModalHidden === 'true') {
+        rootElement.removeAttribute('aria-hidden');
+        const elementWithInert = rootElement as HTMLElement & { inert?: boolean };
+        if (typeof elementWithInert.inert === 'boolean') {
+          elementWithInert.inert = false;
+        } else {
+          rootElement.removeAttribute('inert');
+        }
+        delete rootElement.dataset.languageModalHidden;
+      }
+
+      const previouslyFocusedElement = previouslyFocusedElementRef.current;
+      if (previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function') {
+        previouslyFocusedElement.focus();
+      }
+      previouslyFocusedElementRef.current = null;
+    };
+  }, [isLanguageModalOpen]);
+
+  const closeLanguageModal = () => setIsLanguageModalOpen(false);
+
+  const languageModal =
+    isLanguageModalOpen && typeof document !== 'undefined'
+      ? createPortal(
+          <div className="fixed inset-0 z-50 flex items-center justify-center">
+            <div
+              className="absolute inset-0 bg-black/50"
+              aria-hidden="true"
+              onClick={closeLanguageModal}
+            />
+            <div
+              ref={modalRef}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="language-modal-title"
+              className="relative bg-card border border-border rounded-lg shadow-lg p-6 w-[90%] max-w-sm"
+              tabIndex={-1}
+            >
+              <div className="flex items-start justify-between mb-4">
+                <h2 id="language-modal-title" className="text-lg font-semibold text-card-foreground">
+                  {t('language.title')}
+                </h2>
+                <button
+                  onClick={closeLanguageModal}
+                  className="p-2 rounded-md text-foreground hover:bg-muted"
+                  aria-label={t('app.close')}
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                  <span className="sr-only">{t('app.close')}</span>
+                </button>
+              </div>
+              <p className="text-sm text-muted-foreground mb-4">
+                {t('language.description')}
+              </p>
+              <div className="space-y-2">
+                {[
+                  { code: 'en', label: t('language.english'), shortLabel: t('language.englishShort') },
+                  { code: 'ja', label: t('language.japanese'), shortLabel: t('language.japaneseShort') }
+                ].map(({ code, label, shortLabel }) => {
+                  const isActive = i18n.language === code;
+                  return (
+                    <button
+                      key={code}
+                      onClick={() => {
+                        changeLanguage(code);
+                        closeLanguageModal();
+                      }}
+                      className={`w-full flex items-center justify-between px-3 py-2 rounded-md border transition-colors ${
+                        isActive ? 'border-primary bg-primary/10 text-primary' : 'border-border text-foreground hover:bg-muted'
+                      }`}
+                    >
+                      <span className="text-sm font-medium">{label}</span>
+                      <span className="text-xs text-muted-foreground">{shortLabel}</span>
+                    </button>
+                  );
+                })}
+              </div>
+              <button
+                onClick={closeLanguageModal}
+                className="mt-4 w-full px-3 py-2 text-sm font-medium rounded-md border border-border text-foreground hover:bg-muted"
+              >
+                {t('app.cancel')}
+              </button>
+            </div>
+          </div>,
+          document.body
+        )
+      : null;
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-card border-b border-border">
@@ -139,67 +313,7 @@ export function Header({ onMenuClick }: HeaderProps) {
         </div>
       </div>
 
-      {isLanguageModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <div
-            className="absolute inset-0 bg-black/50"
-            aria-hidden="true"
-            onClick={() => setIsLanguageModalOpen(false)}
-          />
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="language-modal-title"
-            className="relative bg-card border border-border rounded-lg shadow-lg p-6 w-[90%] max-w-sm"
-          >
-            <div className="flex items-start justify-between mb-4">
-              <h2 id="language-modal-title" className="text-lg font-semibold text-card-foreground">
-                {t('language.title')}
-              </h2>
-              <button
-                onClick={() => setIsLanguageModalOpen(false)}
-                className="p-2 rounded-md text-foreground hover:bg-muted"
-                aria-label={t('app.close')}
-              >
-                <X className="h-4 w-4" aria-hidden="true" />
-                <span className="sr-only">{t('app.close')}</span>
-              </button>
-            </div>
-            <p className="text-sm text-muted-foreground mb-4">
-              {t('language.description')}
-            </p>
-            <div className="space-y-2">
-              {[
-                { code: 'en', label: t('language.english'), shortLabel: t('language.englishShort') },
-                { code: 'ja', label: t('language.japanese'), shortLabel: t('language.japaneseShort') }
-              ].map(({ code, label, shortLabel }) => {
-                const isActive = i18n.language === code;
-                return (
-                  <button
-                    key={code}
-                    onClick={() => {
-                      changeLanguage(code);
-                      setIsLanguageModalOpen(false);
-                    }}
-                    className={`w-full flex items-center justify-between px-3 py-2 rounded-md border transition-colors ${
-                      isActive ? 'border-primary bg-primary/10 text-primary' : 'border-border text-foreground hover:bg-muted'
-                    }`}
-                  >
-                    <span className="text-sm font-medium">{label}</span>
-                    <span className="text-xs text-muted-foreground">{shortLabel}</span>
-                  </button>
-                );
-              })}
-            </div>
-            <button
-              onClick={() => setIsLanguageModalOpen(false)}
-              className="mt-4 w-full px-3 py-2 text-sm font-medium rounded-md border border-border text-foreground hover:bg-muted"
-            >
-              {t('app.cancel')}
-            </button>
-          </div>
-        </div>
-      )}
+      {languageModal}
     </header>
   );
 }

--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useCommandPalette } from '@/contexts/CommandPaletteContext';
-import { Menu, User, LogOut, Settings, ChevronDown, Sun, Moon, Languages, Terminal } from 'lucide-react';
+import { Menu, User, LogOut, Settings, ChevronDown, Sun, Moon, Globe, Terminal, X } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -15,6 +15,7 @@ export function Header({ onMenuClick }: HeaderProps) {
   const { theme, toggleTheme } = useTheme();
   const { openCommandPalette } = useCommandPalette();
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const [isLanguageModalOpen, setIsLanguageModalOpen] = useState(false);
   const { t, i18n } = useTranslation('common');
   
   const changeLanguage = (lng: string) => {
@@ -38,7 +39,7 @@ export function Header({ onMenuClick }: HeaderProps) {
               <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
                 <span className="text-primary-foreground font-bold text-lg">P</span>
               </div>
-              <h1 className="text-xl font-semibold text-foreground">
+              <h1 className="hidden md:block text-xl font-semibold text-foreground">
                 {t('app.name')}
               </h1>
             </Link>
@@ -47,17 +48,13 @@ export function Header({ onMenuClick }: HeaderProps) {
           {/* Right side actions */}
           <div className="flex items-center gap-2">
             {/* Language Switcher */}
-            <div className="flex items-center">
-              <Languages className="w-5 h-5 text-muted-foreground mr-2" />
-              <select
-                value={i18n.language}
-                onChange={(e) => changeLanguage(e.target.value)}
-                className="bg-transparent border border-border rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-              >
-                <option value="en">EN</option>
-                <option value="ja">日本語</option>
-              </select>
-            </div>
+            <button
+              onClick={() => setIsLanguageModalOpen(true)}
+              className="p-2 rounded-md text-foreground hover:bg-muted transition-colors"
+              aria-label={t('language.openSelector')}
+            >
+              <Globe className="h-5 w-5" />
+            </button>
             
             {/* Command Palette Button */}
             <button
@@ -141,6 +138,68 @@ export function Header({ onMenuClick }: HeaderProps) {
           </div>
         </div>
       </div>
+
+      {isLanguageModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            aria-hidden="true"
+            onClick={() => setIsLanguageModalOpen(false)}
+          />
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="language-modal-title"
+            className="relative bg-card border border-border rounded-lg shadow-lg p-6 w-[90%] max-w-sm"
+          >
+            <div className="flex items-start justify-between mb-4">
+              <h2 id="language-modal-title" className="text-lg font-semibold text-card-foreground">
+                {t('language.title')}
+              </h2>
+              <button
+                onClick={() => setIsLanguageModalOpen(false)}
+                className="p-2 rounded-md text-foreground hover:bg-muted"
+                aria-label={t('app.close')}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+                <span className="sr-only">{t('app.close')}</span>
+              </button>
+            </div>
+            <p className="text-sm text-muted-foreground mb-4">
+              {t('language.description')}
+            </p>
+            <div className="space-y-2">
+              {[
+                { code: 'en', label: t('language.english'), shortLabel: t('language.englishShort') },
+                { code: 'ja', label: t('language.japanese'), shortLabel: t('language.japaneseShort') }
+              ].map(({ code, label, shortLabel }) => {
+                const isActive = i18n.language === code;
+                return (
+                  <button
+                    key={code}
+                    onClick={() => {
+                      changeLanguage(code);
+                      setIsLanguageModalOpen(false);
+                    }}
+                    className={`w-full flex items-center justify-between px-3 py-2 rounded-md border transition-colors ${
+                      isActive ? 'border-primary bg-primary/10 text-primary' : 'border-border text-foreground hover:bg-muted'
+                    }`}
+                  >
+                    <span className="text-sm font-medium">{label}</span>
+                    <span className="text-xs text-muted-foreground">{shortLabel}</span>
+                  </button>
+                );
+              })}
+            </div>
+            <button
+              onClick={() => setIsLanguageModalOpen(false)}
+              className="mt-4 w-full px-3 py-2 text-sm font-medium rounded-md border border-border text-foreground hover:bg-muted"
+            >
+              {t('app.cancel')}
+            </button>
+          </div>
+        </div>
+      )}
     </header>
   );
 }

--- a/apps/frontend/src/locales/en/common.json
+++ b/apps/frontend/src/locales/en/common.json
@@ -47,6 +47,15 @@
     "required": "Required",
     "optional": "Optional"
   },
+  "language": {
+    "openSelector": "Open language selection",
+    "title": "Choose your language",
+    "description": "Select the language you prefer to use.",
+    "english": "English",
+    "japanese": "Japanese",
+    "englishShort": "EN",
+    "japaneseShort": "JA"
+  },
   "navigation": {
     "dashboard": "Dashboard",
     "todos": "TODOs",

--- a/apps/frontend/src/locales/ja/common.json
+++ b/apps/frontend/src/locales/ja/common.json
@@ -47,6 +47,15 @@
     "required": "必須",
     "optional": "任意"
   },
+  "language": {
+    "openSelector": "言語を選択",
+    "title": "言語を選択してください",
+    "description": "使用する言語を選択してください。",
+    "english": "英語",
+    "japanese": "日本語",
+    "englishShort": "EN",
+    "japaneseShort": "JA"
+  },
   "navigation": {
     "dashboard": "ダッシュボード",
     "todos": "TODO",


### PR DESCRIPTION
## Summary
- hide the product name on mobile so the header keeps the compact icon-only branding
- replace the select input with a globe icon that opens a modal language picker
- add i18n strings for the new modal labels in English and Japanese
- trap focus inside the language modal, close on Escape, and mark the background inert for accessibility

## Testing
- pnpm lint
- pnpm build
- pnpm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Globe button that opens a language selection modal with title, description, close button, and options for English and Japanese with active-state indication.
  - App name now hides on small screens for improved responsiveness.

- Accessibility
  - Improved ARIA labels, focus handling, and modal behavior for keyboard and screen-reader users.

- Localization
  - Introduced translation strings for the language selector in English and Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->